### PR TITLE
[20231218] PRG / lv2 / PCCP 기출문제 2번 / 조재현

### DIFF
--- a/HandamdeCloud/202312/18 PRG PCCP 기출문제 2번.md
+++ b/HandamdeCloud/202312/18 PRG PCCP 기출문제 2번.md
@@ -1,0 +1,44 @@
+```
+
+from collections import deque
+
+dx,dy = [0,0,-1,1],[1,-1,0,0]
+
+def solution(land):
+    row = len(land)
+    col = len(land[0])
+    visited = [[False]*col for _ in range(row)]
+    result = [0 for _ in range(col)]
+    
+    for i in range(row):
+        for j in range(col):
+            if land[i][j] == 1 and not visited[i][j]:
+                bfs(i,j,visited,result,land)
+    
+    return max(result)
+
+def bfs(i :int, j :int, visited :list, result :list, land :list):
+    q = deque()
+    q.append([i,j])
+
+    labeled = set()
+    labeled.add(j)
+    
+    visited[i][j] = True
+    count = 1
+
+    while q:
+        x,y = q.popleft()
+        for i in range(4):
+            nx,ny = dx[i]+x, dy[i]+y
+            if 0 <= nx < len(land) and 0<= ny < len(land[0]) and not visited[nx][ny]:
+                if land[nx][ny] == 1:
+                    q.append([nx,ny])
+                    labeled.add(ny)
+                    count += 1
+                    visited[nx][ny] = True                        
+
+    for i in labeled:
+        result[i] += count
+
+```


### PR DESCRIPTION
### 풀이 시간 : 40분
### 체감 난이도 : 중
### 문제 설명
2차원 land리스트가 주어졌을 때 열별로 석유를 시추한다.
이때 가장 많은 석유를 얻을 수 있는 양을 구하기
### 생각한 방법
시도 1 : bfs로 그룹의 총 크기를 찾기, 그룹을 만들기, 열별로 탐색 시 어떤 그룹에 속해있는지 확인하고 그룹의 크기를 더해주기
시도 2 : bfs로 그룹을 총 크기를 찾기, 열별로 그룹의 크기를 누적합 ✅ 

우선 bfs로 같은 그룹의 크기를 찾는 방법이 필요했다. (일반적인 bfs)
그리고 석유를 시추하는 과정에서 이 결과를 어떻게 활용해야할지 고민하는 과정이 관건이었다.

1. 열별로 탐색을 하는점
2. 석유가 확인된 지점은 그 그룹의 값을 모두 그 열에 반영해야 한다.

이 두가지 특징을 바탕으로 열별로 결과를 나타내는 result라는 리스트를 만들었다.
그리고 누적합 방식으로 해당 그룹이 걸쳐있는 열위치의 그룹의 크기를 더해주고 최대값을 구해 문제를 해결했다.