### PR TITLE
[20231219] BAJ/골드3/색상환/구범모

### DIFF
--- a/BeommoKoo-dev/202312/18 BAJ 1987 알파벳.md
+++ b/BeommoKoo-dev/202312/18 BAJ 1987 알파벳.md
@@ -1,0 +1,59 @@
+```
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    boolean[] visited;
+    int r, c, answer;
+    int[] dx = {0, 1, 0, -1};
+    int[] dy = {1, 0, -1, 0};
+    char[][] map;
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        r = Integer.parseInt(st.nextToken());
+        c = Integer.parseInt(st.nextToken());
+        visited = new boolean[26];
+        map = new char[r + 1][c + 1];
+        for(int i = 1; i <= r; i++) {
+            String s = br.readLine();
+            for(int j = 1; j <= c; j++) {
+                map[i][j] = s.charAt(j - 1);
+            }
+        }
+    }
+
+    private void dfs(int x, int y, int val) {
+        answer = Math.max(answer, val);
+
+        for(int i = 0; i < 4; i++) {
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+
+            if(nx < 1 || ny < 1 || nx > r || ny > c || visited[map[nx][ny] - 'A']) {
+                continue;
+            }
+
+            visited[map[nx][ny] - 'A'] = true;
+            dfs(nx, ny, val + 1);
+            visited[map[nx][ny] - 'A'] = false;
+        }
+    }
+
+    private void solution() throws IOException {
+        input();
+        visited[map[1][1] - 'A'] = true;
+        dfs(1, 1, 1);
+        System.out.println(answer);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+```

--- a/BeommoKoo-dev/202312/19 BAJ 2482 색상환.md
+++ b/BeommoKoo-dev/202312/19 BAJ 2482 색상환.md
@@ -1,0 +1,40 @@
+```
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+
+    int n, k, MOD = 1_000_000_003;
+    long[][] dp;
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        k = Integer.parseInt(br.readLine());
+        dp = new long[n + 1][k + 1];
+    }
+
+    private void solution() throws IOException {
+        input();
+        for(int i = 1; i <= n; i++) {
+            dp[i][1] = i;
+            dp[i][0] = 1;
+        }
+        for(int i = 2; i <= n; i++) {
+            for(int j = 2; j <= k; j++) {
+                dp[i][j] = (dp[i - 2][j - 1] + dp[i - 1][j]) % MOD;
+            }
+        }
+
+        int ans = (int)((dp[n - 1][k] + dp[n - 3][k - 1]) % MOD);
+        System.out.println(ans);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+```

--- a/BeommoKoo-dev/202312/19 BAJ 2482 색상환.md
+++ b/BeommoKoo-dev/202312/19 BAJ 2482 색상환.md
@@ -17,9 +17,8 @@ public class Main {
 
     private void solution() throws IOException {
         input();
-        for(int i = 1; i <= n; i++) {
+        for(int i = 2; i <= n; i++) {
             dp[i][1] = i;
-            dp[i][0] = 1;
         }
         for(int i = 2; i <= n; i++) {
             for(int j = 2; j <= k; j++) {
@@ -27,8 +26,7 @@ public class Main {
             }
         }
 
-        int ans = (int)((dp[n - 1][k] + dp[n - 3][k - 1]) % MOD);
-        System.out.println(ans);
+        System.out.println((int)(dp[n][k]));
     }
 
     public static void main(String[] args) throws IOException {
@@ -36,5 +34,6 @@ public class Main {
     }
 
 }
+
 
 ```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2482

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
n개의 색 중 k개를 칠하는 방법의 수 찾기.

## 🔍 풀이 방법
점화식을 세워 풀 수 있다.
dp[n][k]를 n개의 칸 중 k개의 인접하지 않은 칸을 선택하여 색칠하는 경우의 수라고 하자.
dp[n][1]은 항상 n임이 보장된다.
이후 n개의 칸 중 k개의 인접하지 않은 칸을 선택하여 색칠하는 경우의 수는,
1 : n번째 칸을 색칠하는 경우 : n-1번째, 1번째 칸 둘다 색칠하지 못하므로, n-2개의 칸 중 k-1개의 칸을 색칠하는 경우의 수 : dp[n-2][k-1]
2 : n번째 칸을 색칠하지 않는 경우 : 1~n-1번째 칸을 k개 색칠하는 경우의 수 : dp[n-1][k]
1 + 2의 경우의 수를 더해주면 된다.

## ⏳ 회고
점화식 어려워요ㅠ