### PR TITLE
[20231226] BAJ/골드3/앱/구범모

### DIFF
--- a/BeommoKoo-dev/202312/18 BAJ 1987 알파벳.md
+++ b/BeommoKoo-dev/202312/18 BAJ 1987 알파벳.md
@@ -1,0 +1,59 @@
+```
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    boolean[] visited;
+    int r, c, answer;
+    int[] dx = {0, 1, 0, -1};
+    int[] dy = {1, 0, -1, 0};
+    char[][] map;
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        r = Integer.parseInt(st.nextToken());
+        c = Integer.parseInt(st.nextToken());
+        visited = new boolean[26];
+        map = new char[r + 1][c + 1];
+        for(int i = 1; i <= r; i++) {
+            String s = br.readLine();
+            for(int j = 1; j <= c; j++) {
+                map[i][j] = s.charAt(j - 1);
+            }
+        }
+    }
+
+    private void dfs(int x, int y, int val) {
+        answer = Math.max(answer, val);
+
+        for(int i = 0; i < 4; i++) {
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+
+            if(nx < 1 || ny < 1 || nx > r || ny > c || visited[map[nx][ny] - 'A']) {
+                continue;
+            }
+
+            visited[map[nx][ny] - 'A'] = true;
+            dfs(nx, ny, val + 1);
+            visited[map[nx][ny] - 'A'] = false;
+        }
+    }
+
+    private void solution() throws IOException {
+        input();
+        visited[map[1][1] - 'A'] = true;
+        dfs(1, 1, 1);
+        System.out.println(answer);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+```

--- a/BeommoKoo-dev/202312/19 BAJ 2482 색상환.md
+++ b/BeommoKoo-dev/202312/19 BAJ 2482 색상환.md
@@ -1,0 +1,40 @@
+```
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+
+    int n, k, MOD = 1_000_000_003;
+    long[][] dp;
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        k = Integer.parseInt(br.readLine());
+        dp = new long[n + 1][k + 1];
+    }
+
+    private void solution() throws IOException {
+        input();
+        for(int i = 1; i <= n; i++) {
+            dp[i][1] = i;
+            dp[i][0] = 1;
+        }
+        for(int i = 2; i <= n; i++) {
+            for(int j = 2; j <= k; j++) {
+                dp[i][j] = (dp[i - 2][j - 1] + dp[i - 1][j]) % MOD;
+            }
+        }
+
+        int ans = (int)((dp[n - 1][k] + dp[n - 3][k - 1]) % MOD);
+        System.out.println(ans);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+```

--- a/BeommoKoo-dev/202312/19 BAJ 2482 색상환.md
+++ b/BeommoKoo-dev/202312/19 BAJ 2482 색상환.md
@@ -17,9 +17,8 @@ public class Main {
 
     private void solution() throws IOException {
         input();
-        for(int i = 1; i <= n; i++) {
+        for(int i = 2; i <= n; i++) {
             dp[i][1] = i;
-            dp[i][0] = 1;
         }
         for(int i = 2; i <= n; i++) {
             for(int j = 2; j <= k; j++) {
@@ -27,8 +26,7 @@ public class Main {
             }
         }
 
-        int ans = (int)((dp[n - 1][k] + dp[n - 3][k - 1]) % MOD);
-        System.out.println(ans);
+        System.out.println((int)(dp[n][k]));
     }
 
     public static void main(String[] args) throws IOException {
@@ -36,5 +34,6 @@ public class Main {
     }
 
 }
+
 
 ```

--- a/BeommoKoo-dev/202312/20 BAJ 1332 풀자.md
+++ b/BeommoKoo-dev/202312/20 BAJ 1332 풀자.md
@@ -1,0 +1,68 @@
+```
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    int n, v, max = -1, min = Integer.MAX_VALUE, ans = Integer.MAX_VALUE;
+    int[] arr;
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        v = Integer.parseInt(st.nextToken());
+        arr = new int[n];
+        ans = n;
+        st = new StringTokenizer(br.readLine());
+
+        for(int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+            max = Math.max(max, arr[i]);
+            min = Math.min(min, arr[i]);
+        }
+    }
+
+    private void dfs(int idx, int max, int min, int count) {
+        if(idx >= n) {
+            ans = Math.min(ans, count);
+            return;
+        }
+
+        if(count > ans) {
+            return;
+        }
+
+        int cMax = Math.max(arr[idx], max);
+        int cMin = Math.min(arr[idx], min);
+
+        if(cMax - cMin >= v) {
+            ans = Math.min(ans, count);
+            return;
+        }
+
+        dfs(idx + 1, cMax, cMin, count + 1);
+        dfs(idx + 2, cMax, cMin, count + 1);
+    }
+
+    private void solution() throws IOException {
+        input();
+        if(max - min < v) {
+            System.out.println(n);
+            return;
+        }
+        max = arr[0];
+        min = arr[0];
+
+        dfs(0, 0, 1000, 1);
+        System.out.println(ans);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+```

--- a/BeommoKoo-dev/202312/21 BAJ 2234 성곽.md
+++ b/BeommoKoo-dev/202312/21 BAJ 2234 성곽.md
@@ -1,0 +1,168 @@
+```
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+    // x, y, dir wall
+    // 서 : 1 북 : 2 동 : 4 남 : 8
+    // 남 동 북 서
+    int[][][] map;
+    boolean[][] visited;
+    Pair[][] clusters;
+    int n, m, ansOne, ansTwo, ansThree;
+    int[] dx = {1, 0, -1, 0};
+    int[] dy = {0, 1, 0, -1};
+
+    // 넓이, 번호
+    class Pair {
+        int first, second;
+
+        public Pair(int first, int second) {
+            this.first = first;
+            this.second = second;
+        }
+    }
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        m = Integer.parseInt(st.nextToken());
+        n = Integer.parseInt(st.nextToken());
+        map = new int[n + 1][m + 1][4];
+        visited = new boolean[n + 1][m + 1];
+        clusters = new Pair[n + 1][m + 1];
+        for(int i = 1; i <= n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for(int j = 1; j <= m; j++) {
+                int tmp = Integer.parseInt(st.nextToken());
+                String s = Integer.toBinaryString(tmp);
+                String ss = "";
+                if(s.length() < 4) {
+                    int len = 4 - s.length();
+                    for(int k = 0; k < len; k++) {
+                        ss += "0";
+                    }
+                    ss += s;
+                }
+                else {
+                    ss = s;
+                }
+                for(int k = 0; k < 4; k++) {
+                    char c = ss.charAt(k);
+                    map[i][j][k] = c - '0';
+                }
+            }
+        }
+    }
+
+    private int bfs(int sx, int sy, int cluster) {
+        Queue<Pair> q = new LinkedList<>();
+        List<Pair> list = new ArrayList<>();
+        visited[sx][sy] = true;
+        q.add(new Pair(sx, sy));
+        list.add(new Pair(sx, sy));
+        int res = 1;
+
+        while (!q.isEmpty()) {
+            Pair p = q.poll();
+            int x = p.first;
+            int y = p.second;
+
+            for(int i = 0; i < 4; i++) {
+                int nx = x + dx[i];
+                int ny = y + dy[i];
+
+                if(nx < 1 || ny < 1 || nx > n || ny > m || visited[nx][ny]) {
+                    continue;
+                }
+
+                if(map[x][y][i] == 1) {
+                    continue;
+                }
+
+                res++;
+                visited[nx][ny] = true;
+                q.add(new Pair(nx, ny));
+                list.add(new Pair(nx, ny));
+            }
+        }
+
+        for(int i = 0; i < list.size(); i++) {
+            Pair p = list.get(i);
+            int x = p.first;
+            int y = p.second;
+
+            Pair newPair = new Pair(cluster, res);
+            clusters[x][y] = newPair;
+        }
+
+        return res;
+    }
+
+    private void dfs(int x, int y, int cluster) {
+        for(int i = 0; i < 4; i++) {
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+
+            if(nx < 1 || ny < 1 || nx > n || ny > m || visited[nx][ny]) {
+                continue;
+            }
+
+            if(map[x][y][i] == 1) {
+                if((clusters[nx][ny].first != cluster)) {
+                    ansThree = Math.max(ansThree, clusters[nx][ny].second + clusters[x][y].second);
+                }
+                continue;
+            }
+
+            visited[nx][ny] = true;
+            dfs(nx, ny, cluster);
+        }
+    }
+
+    private void solution() throws IOException {
+        input();
+        int cluster = 1;
+        // wall이 있고, 다른 클러스터인 경우에만 포함해야 함.
+        for(int i = 1; i <= n; i++) {
+            for(int j = 1; j <= m; j++) {
+                if (!visited[i][j]) {
+                    int res = bfs(i, j, cluster);
+                    ansTwo = Math.max(ansTwo, res);
+                    ansOne++;
+                    cluster++;
+                }
+            }
+        }
+        for(int i = 1; i <= n; i++) {
+            Arrays.fill(visited[i], false);
+        }
+
+        for(int i = 1; i <= n; i++) {
+            for(int j = 1; j <= m; j++) {
+                if(!visited[i][j]) {
+                    visited[i][j] = true;
+                    dfs(i, j, clusters[i][j].first);
+                }
+            }
+        }
+
+        System.out.println(ansOne);
+        System.out.println(ansTwo);
+        System.out.println(ansThree);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+```

--- a/BeommoKoo-dev/202312/22 BAJ 21736 헌내기는 친구가 필요해.md
+++ b/BeommoKoo-dev/202312/22 BAJ 21736 헌내기는 친구가 필요해.md
@@ -1,0 +1,98 @@
+```
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    class Pair {
+        int first, second;
+
+        public Pair(int first, int second) {
+            this.first = first;
+            this.second = second;
+        }
+    }
+
+    int[] dx = {0, 1, 0, -1};
+    int[] dy = {1, 0, -1, 0};
+    int[][] map;
+    boolean[][] visited;
+    int n, m, sx, sy, ans;
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        map = new int[n + 1][m + 1];
+        visited = new boolean[n + 1][m + 1];
+        for(int i = 1; i <= n; i++) {
+            String s = br.readLine();
+            for(int j = 1; j <= m; j++) {
+                if(s.charAt(j - 1) == 'O') {
+                    map[i][j] = 1;
+                }
+                if(s.charAt(j - 1) == 'X') {
+                    map[i][j] = 0;
+                }
+                if(s.charAt(j - 1) == 'I') {
+                    sx = i;
+                    sy = j;
+                    map[i][j] = 3;
+                }
+                if(s.charAt(j - 1) == 'P') {
+                    map[i][j] = 2;
+                }
+            }
+        }
+    }
+
+    private void bfs() {
+        Queue<Pair> q = new LinkedList<>();
+        visited[sx][sy] = true;
+        q.add(new Pair(sx, sy));
+
+        while (!q.isEmpty()) {
+            Pair p = q.poll();
+            int x = p.first;
+            int y = p.second;
+
+            for(int i = 0; i < 4; i++) {
+                int nx = x + dx[i];
+                int ny = y + dy[i];
+
+                if(nx < 1 || ny < 1 || nx > n || ny > m || visited[nx][ny] || map[nx][ny] == 0) {
+                    continue;
+                }
+
+                if(map[nx][ny] == 2) {
+                    ans++;
+                }
+                visited[nx][ny] = true;
+                q.add(new Pair(nx, ny));
+            }
+        }
+    }
+
+    private void solution() throws IOException {
+        input();
+        bfs();
+        if(ans > 0) {
+            System.out.println(ans);
+        }
+        else {
+            System.out.println("TT");
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+```

--- a/BeommoKoo-dev/202312/23 BAJ 7579 앱.md
+++ b/BeommoKoo-dev/202312/23 BAJ 7579 앱.md
@@ -1,0 +1,60 @@
+```java
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    int n, m, ans = Integer.MAX_VALUE;
+    int[] a, c;
+    int[] dp;
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        a = new int[n + 1];
+        c = new int[n + 1];
+        dp = new int[10001];
+
+        st = new StringTokenizer(br.readLine());
+        for(int i = 1; i <= n; i++) {
+            a[i] = Integer.parseInt(st.nextToken());
+        }
+
+        st = new StringTokenizer(br.readLine());
+        for(int i = 1; i <= n; i++) {
+            c[i] = Integer.parseInt(st.nextToken());
+        }
+    }
+
+    private void solution() throws IOException {
+        input();
+        for(int i = 1; i <= n; i++) {
+            for(int j = 10000; j >= 0; j--) {
+                if(c[i] <= j) {
+                    dp[j] = Math.max(dp[j], dp[j - c[i]] + a[i]);
+                }
+            }
+        }
+
+        for(int i = 0; i <= 10000; i++) {
+            if(dp[i] >= m) {
+                ans = Math.min(ans, i);
+            }
+        }
+
+        System.out.println(ans);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
링크 : https://www.acmicpc.net/problem/7579

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
필요한 용량(M)을 채우는 데 필요한 최소 비용(C)를 구하는 문제.

## 🔍 풀이 방법
처음엔 그리디하게 접근하려 했지만, 문제분류를 확인했는데 냅색 알고리즘이였다.
알고리즘을 확인한 이후에 그리디의 반례를 찾아서, 냅색으로 접근하려 했으나
기존의 냅색 알고리즘으로 접근하려면 용량의 최댓값을 dp배열의 크기로 선언해야 한다.
하지만 이것은 메모리 초과가 날것이므로, 비용을 dp배열의 크기로 선언하여 dp배열에 들어가는 값을
용량으로 잡아주어서 해결하였다.

## ⏳ 회고
최적화에서 한번 더 최적화가 일어난 느낌이라, 많이 배워갔던 문제.