### PR TITLE
[20240111] PRG / lv3 / 섬 연결하기 / 박이슬

### DIFF
--- a/Yiseull/202401/11 PRG 섬 연결하기.md
+++ b/Yiseull/202401/11 PRG 섬 연결하기.md
@@ -1,0 +1,38 @@
+```python
+'''
+1. 건설 비용이 적은 순으로 정렬한다.
+2. 건설했을 때 사이클이 생기지 않는 두 섬을 연결한다.
+'''
+from collections import deque
+
+
+def exists_cycle(n, graph, start) -> bool:
+    visited = [-1] * n
+    visited[start] = 0
+    q = deque([start])
+    while q:
+        v = q.popleft()
+        for w in graph[v]:
+            if visited[w] == -1:
+                visited[w] = v
+                q.append(w)
+            elif visited[v] != w:
+                return True
+    return False
+
+
+def solution(n, costs) -> int:
+    answer = 0
+    graph = [[] for i in range(n + 1)]
+    costs.sort(key=lambda x: x[2])
+    for cost in costs:
+        graph[cost[0]].append(cost[1])
+        graph[cost[1]].append(cost[0])
+        if not exists_cycle(n, graph, cost[0]):
+            answer += cost[2]
+        else:
+            graph[cost[0]].pop()
+            graph[cost[1]].pop()
+
+    return answer
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/42861

## 🧭 풀이 시간
70분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
n개의 섬 사이에 다리를 건설하는 비용(costs)이 주어질 때, 최소의 비용으로 모든 섬이 서로 통행 가능하도록 만들 때 필요한 최소 비용을 return 하도록 solution을 완성하세요.

다리를 여러 번 건너더라도, 도달할 수만 있으면 통행 가능하다고 봅니다. 예를 들어 A 섬과 B 섬 사이에 다리가 있고, B 섬과 C 섬 사이에 다리가 있으면 A 섬과 C 섬은 서로 통행 가능합니다.

## 🔍 풀이 방법
전체 건설 비용이 최소가 되도록 하려면 건설 비용이 작은 것부터 건설을 하면 된다. 이때 가장 중요한 것은 ✨사이클✨이 생기지 않도록 하는 것이다.

사이클은 BFS를 통해 확인한다. 
1. visited 배열에 자신의 이전 방문 섬을 넣는다. `visited[v] = w` 는 v가 w에서 넘어와서 방문한 것을 뜻한다.
2. BFS를 돌면서 이미 방문한 적 있는 섬을 만났을 때, 그 섬이 자신의 이전 방문 섬이 아니라면(=서로 연결되어 있는 섬이 아니라면) 사이클이 생긴 것으로 간주한다.

## ⏳ 회고
문제를 읽어 나가는 도중에 어떻게 풀어야할지 떠올라서 풀이를 생각해내는 것은 어렵지 않았다.
그런데도 풀이 시간이 오래 걸린 것은 사이클을 확인하는 로직이 자꾸 틀렸기 때문이다.  머릿 속에서는 '이렇게 접근하면 되겠다!' 생각은 했지만 그걸 코드로 풀어내는 과정에서 생각 그대로 잘 풀어내지 못했다.

항상 느끼는 거지만 나는 알고리즘 문제를 푸는데 꼼꼼함이 부족한 것 같다. 한 번에 통과하는 경우가 드물고 항상 제출하고 틀린 것을 토대로 디버깅 하며 고쳐나간다. 하지만 실제 코딩테스트에서는 디버깅이 어렵기 때문에 한 번 풀 때 최대한 모든 경우의 수를 고려해서 풀도록 연습해야겠다. 💪😤