### PR TITLE
[20240117] BAJ/골드4/두 동전/구범모

### DIFF
--- a/BeommoKoo-dev/202401/17 BAJ 16197 두 동전.md
+++ b/BeommoKoo-dev/202401/17 BAJ 16197 두 동전.md
@@ -1,0 +1,127 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    int[][] map;
+    boolean[][][][] visited;
+    int[] dx = {0, 1, 0, -1};
+    int[] dy = {1, 0, -1, 0};
+    int n, m, x, xx, y, yy;
+
+    class Coins {
+        int x, xx, y, yy, count;
+
+        public Coins(int x, int y, int xx, int yy, int count) {
+            this.x = x;
+            this.xx = xx;
+            this.y = y;
+            this.yy = yy;
+            this.count = count;
+        }
+    }
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        map = new int[n + 1][m + 1];
+        visited = new boolean[n + 1][m + 1][n + 1][m + 1];
+        boolean flag = false;
+        for (int i = 1; i <= n; i++) {
+            String s = br.readLine();
+            for (int j = 1; j <= m; j++) {
+                if (s.charAt(j - 1) == 'o') {
+                    if(!flag) {
+                        x = i;
+                        y = j;
+                        flag = true;
+                    }
+                    else {
+                        xx = i;
+                        yy = j;
+                    }
+                } else if (s.charAt(j - 1) == '#') {
+                    map[i][j] = -1;
+                }
+            }
+        }
+    }
+
+    private boolean isInRange(int x, int y) {
+        if (x < 1 || y < 1 || x > n || y > m) {
+            return false;
+        }
+        return true;
+    }
+
+    private int bfs() {
+        Queue<Coins> q = new LinkedList<>();
+        q.add(new Coins(x, y, xx, yy, 0));
+        while (!q.isEmpty()) {
+            Coins c = q.poll();
+            int x = c.x;
+            int y = c.y;
+            int xx = c.xx;
+            int yy = c.yy;
+            int count = c.count;
+
+            for (int i = 0; i < 4; i++) {
+                int nx = x + dx[i];
+                int ny = y + dy[i];
+                int nxx = xx + dx[i];
+                int nyy = yy + dy[i];
+
+                if (!isInRange(nx, ny) && !isInRange(nxx, nyy)) {
+                    continue;
+                }
+
+                if (!isInRange(nx, ny) || !isInRange(nxx, nyy)) {
+                    return count + 1;
+                }
+
+                if (count == 10) {
+                    return -1;
+                }
+
+                if(map[nx][ny] == -1) {
+                    nx = x;
+                    ny = y;
+                }
+                if (map[nxx][nyy] == -1) {
+                    nxx = xx;
+                    nyy = yy;
+                }
+
+                if(visited[nx][ny][nxx][nyy]) {
+                    continue;
+                }
+
+                visited[nx][ny][nxx][nyy] = true;
+                q.add(new Coins(nx, ny, nxx, nyy, count + 1));
+            }
+        }
+
+        return -1;
+    }
+
+    private void solution() throws IOException {
+        input();
+        System.out.println(bfs());
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16197

## 🧭 풀이 시간
20 분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
두 동전을 동시에 이동시켜서, 보드 밖으로 하나의 동전만 떨어뜨릴 때 드는 최소 이동 횟수

## 🔍 풀이 방법
두 동전을 하나의 노드로 생각해서 bfs를 돌린다. 따라서 visited배열도 두 동전의 x,y좌표를 각각 담은 4차원 배열로 선언하였다.

## ⏳ 회고
count >= 10인경우 -1을 리턴해야 하는 점을 깜빡해서 한번 틀렸다. 문제 조건 잘 보자.