### PR TITLE
[20240118] BAJ/골드4/카드 정리1/구범모

### DIFF
--- a/BeommoKoo-dev/202401/18 BAJ 1101 카드 정리1.md
+++ b/BeommoKoo-dev/202401/18 BAJ 1101 카드 정리1.md
@@ -1,0 +1,71 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    int n, m, ans;
+    int[][] arr;
+    boolean[] visited;
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        arr = new int[n + 1][m + 1];
+        visited = new boolean[m + 1];
+        ans = n;
+        for (int i = 1; i <= n; i++) {
+            int count = 0;
+            st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= m; j++) {
+                arr[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+    }
+
+    private void solution() throws IOException {
+        input();
+        for (int joker = 1; joker <= n; joker++) {
+            int val = 0;
+            Arrays.fill(visited, false);
+            for (int i = 1; i <= n; i++) {
+                if (i == joker) {
+                    continue;
+                }
+                int count = 0, pos = 0;
+                for (int j = 1; j <= m; j++) {
+                    if (arr[i][j] > 0) {
+                        count++;
+                        pos = j;
+                    }
+                }
+                if (count == 1) {
+                    if (!visited[pos]) {
+                        visited[pos] = true;
+                    }
+                    else {
+                        val++;
+                    }
+                }
+                else if(count > 1){
+                    val++;
+                }
+            }
+            ans = Math.min(ans, val);
+        }
+        System.out.println(ans);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1101

## 🧭 풀이 시간
50 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
문제 조건에 맞도록 카드를 이동시킬 때, 최소 이동 횟수를 구하는 문제.

## 🔍 풀이 방법
상자의 갯수(N)이 작으므로, 모든 상자를 한번씩 조커 상자로 만들어 본 이후, 나머지 상자에서 
1. 카드가 아예 없는 경우 : continue
2. 카드가 1종류 있는 경우
2-1. 이전에 해당 색상이 나온 경우에는 이동횟수++
2-2. 이전에 해당 색상이 나오지 않은 경우에는 visited배열을 true로만 바꿔주기
3. 카드가 2종류 이상 있는 경우 : 이동횟수++
를 세서 답을 최소로 갱신한다.

## ⏳ 회고
처음에는 무조건 카드의 종류가 많은 상자를 조커 상자로 지정해두면 된다는 생각을 했는데, 맞왜틀 하다가 풀이를 찾아보니 꼭 그런것만은 아니였다. 반례는 아직 찾지 못했지만, 앞으로 n이 작은 경우에는 이번 기회를 떠올려서 완탐으로 모든 경우를 체크하는 것이 더 좋을것 같다는 생각이 든다.