### PR TITLE
[20240124] BOJ / 골드5 / 계란으로 계란치기 / 조재현

### DIFF
--- a/HandamdeCloud/202401/24 BOJ 16987 계란으로 계란치기.md
+++ b/HandamdeCloud/202401/24 BOJ 16987 계란으로 계란치기.md
@@ -1,0 +1,47 @@
+```python
+n = int(input())
+eggs = [list(map(int,input().split())) for _ in range(n)]
+answer = 0
+
+def dfs(start : int) -> None:
+    global answer
+
+    if start == n:
+        cnt = 0
+        for i in eggs:
+            if i[0] <= 0:
+                cnt += 1
+        answer = max(cnt,answer)                
+        return
+    
+    if eggs[start][0] <= 0:
+        dfs(start+1)
+        return
+    
+    check=True
+    for i in range(n):
+        if i==start:
+            continue
+        if eggs[i][0]>0:
+            check=False
+            break
+
+    if check: #다 깨져있는 경우
+        answer=max(answer , n-1) #자기빼고 전부다니깐 n-1
+        return
+      
+    for i in range(n):
+        if eggs[i][0] <= 0 or i == start:
+            continue
+
+        eggs[i][0] -= eggs[start][1] #선택 계란이 현재 계란에 의해 내구도 감소
+        eggs[start][0] -= eggs[i][1] # 현재 계란이 선택 계란에 의해 내구도 감소
+        dfs(start+1)
+        eggs[i][0] += eggs[start][1]
+        eggs[start][0] += eggs[i][1]
+        
+dfs(0)
+
+print(eggs)
+print(answer)
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/16987

## 🧭 풀이 시간
60 분 - 실패

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
계란으로 계란을 쳐서 깨진 계란을 count한다.

## 🔍 풀이 방법
1. 파괴 복구 과정이 들어있다. 내구도를 임의의 변수로 주고 처리하려고 해서 기존 값이 제대로 복구되지 못하는 문제가 있었음
2. 진행 과정중 엣지케이스를 고려하는 과정에서 상당한 시간을 소모했지만, 그 값을 처리해주는 방법을 떠올리지 못해 실패함

## ⏳ 회고
디버깅 과정이 굉장히 인상적이었다. 풀이에서 잘못된점을 찾고 그걸 고쳐나가는 과정이 도움이 많이 된 듯하다.
다만, 엣지케이스를 고려하는 프로그래밍은 아직 부족한 듯 하다. 그 경우의수를 직접 노가다이더라도 해보는 연습이 필요하다. 
그리고 dfs풀이가 고착화되면서 문제를 푸는 형ㅇ식에서 습관적인 모습도 나온 것 같다. 다시 문제를 읽고 내가 생각한 풀이인지 생각할 필요가 있다. 
