### PR TITLE
[20240125] BAJ/골드3/레이저 통신/구범모

### DIFF
--- a/BeommoKoo-dev/202401/25 BAJ 6087 레이저 통신.md
+++ b/BeommoKoo-dev/202401/25 BAJ 6087 레이저 통신.md
@@ -1,0 +1,129 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    int sx, sy, ex, ey, n, m, ans = Integer.MAX_VALUE;
+    int[][] map;
+    // x y 방향
+    int[][][] visited;
+    // 동 남 서 북
+    int[] dx = {0, 1, 0, -1};
+    int[] dy = {1, 0, -1, 0};
+
+    class Node {
+        int x, y, d, count;
+
+        public Node(int x, int y, int d, int count) {
+            this.x = x;
+            this.y = y;
+            this.count = count;
+            this.d = d;
+        }
+    }
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        m = Integer.parseInt(st.nextToken());
+        n = Integer.parseInt(st.nextToken());
+        map = new int[n + 1][m + 1];
+        visited = new int[n + 1][m + 1][4];
+        for (int i = 1; i <= n; i++) {
+            String s = br.readLine();
+            for (int j = 1; j <= m; j++) {
+                char c = s.charAt(j - 1);
+                if (c == '.') {
+                    map[i][j] = 1;
+                }
+                if (c == 'C') {
+                    if (sx == 0) {
+                        sx = i;
+                        sy = j;
+                    }
+                    else {
+                        ex = i;
+                        ey = j;
+                    }
+                    map[i][j] = 1;
+                }
+                Arrays.fill(visited[i][j], Integer.MAX_VALUE);
+            }
+        }
+    }
+
+    private boolean isInRange(int x, int y) {
+        if (x < 1 || y < 1 || x > n || y > m) {
+            return false;
+        }
+        return true;
+    }
+
+    private void bfs() {
+        Queue<Node> q = new LinkedList<>();
+        for (int i = 0; i < 4; i++) {
+            visited[sx][sy][i] = 0;
+        }
+        // visited는 따로 check x
+        q.add(new Node(sx, sy, -1, 0));
+        while (!q.isEmpty()) {
+            Node n = q.poll();
+            int x = n.x;
+            int y = n.y;
+            int d = n.d;
+            int count = n.count;
+
+            if (d == -1) {
+                for (int i = 0; i < 4; i++) {
+                    int nx = x + dx[i];
+                    int ny = y + dy[i];
+                    if (!isInRange(nx, ny) || map[nx][ny] == 0) {
+                        continue;
+                    }
+                    visited[nx][ny][i] = 0;
+                    q.add(new Node(nx, ny, i, 0));
+                }
+            }
+            else {
+                for (int i = 0; i < 4; i++) {
+                    int nx = x + dx[i];
+                    int ny = y + dy[i];
+                    int nCount = count;
+                    if (Math.abs(d - i) != 2 && d != i) {
+                        nCount++;
+                    }
+                    if (!isInRange(nx, ny) || visited[nx][ny][i] <= nCount || map[nx][ny] == 0) {
+                        continue;
+                    }
+                    if (nx == ex && ny == ey) {
+                        ans = Math.min(ans, nCount);
+                        continue;
+                    }
+                    visited[nx][ny][i] = nCount;
+                    q.add(new Node(nx, ny, i, nCount));
+                }
+            }
+        }
+    }
+
+    private void solution() throws IOException {
+        input();
+        bfs();
+        System.out.println(ans);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+
+```

--- a/BeommoKoo-dev/202401/26 BAJ 17136 색종이 붙이기.md
+++ b/BeommoKoo-dev/202401/26 BAJ 17136 색종이 붙이기.md
@@ -1,0 +1,115 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    int MAX = 10, ans = Integer.MAX_VALUE;
+    int[][] map;
+    int[] paper;
+
+    private void input() throws IOException {
+        map = new int[11][11];
+        paper = new int[6];
+        for (int i = 1; i <= 5; i++) {
+            paper[i] = 5;
+        }
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        for (int i = 1; i <= MAX; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= MAX; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+    }
+
+    private boolean isInRange(int x, int y) {
+        if (x < 1 || y < 1 || x > MAX || y > MAX) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean check(int x, int y, int len) {
+        if (!isInRange(x + len - 1, y + len - 1)) {
+            return false;
+        }
+        for (int i = x; i < x + len; i++) {
+            for (int j = y; j < y + len; j++) {
+                if (map[i][j] != 1) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private void dfs(int x, int y, int count) {
+        if (x == MAX + 1 && y == 1) {
+            ans = Math.min(ans, count);
+            return;
+        }
+
+        if (map[x][y] == 0) {
+            if (y == MAX) {
+                dfs(x + 1, 1, count);
+            }
+            else {
+                dfs(x, y + 1, count);
+            }
+        }
+
+        else {
+            for (int l = 1; l <= 5; l++) {
+                if (paper[l] > 0) {
+                    if (check(x, y, l)) {
+                        paper[l]--;
+                        for (int i = x; i < x + l; i++) {
+                            for (int j = y; j < y + l; j++) {
+                                map[i][j] = 0;
+                            }
+                        }
+                        // y + l > MAX이면, x + l이 아닌, x + 1부터 시작.
+                        if (y + l > MAX) {
+                            dfs(x + 1, 1, count + 1);
+                        }
+                        else {
+                            dfs(x, y + l, count + 1);
+                        }
+                        for (int i = x; i < x + l; i++) {
+                            for (int j = y; j < y + l; j++) {
+                                map[i][j] = 1;
+                            }
+                        }
+                        paper[l]++;
+                    }
+                }
+            }
+        }
+    }
+
+    private void solution() throws IOException {
+        input();
+        boolean flag = true;
+        // greedy하게 마주치는거 바로 0으로 만들면 안된다.
+        // 모든 경우의 수를 따져봐야 한다.
+        // 반례 : 예제 5
+        dfs(1, 1, 0);
+
+        if (ans == Integer.MAX_VALUE) {
+            ans = -1;
+        }
+        System.out.println(ans);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/6087

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
C로 표시되어 있는 두 칸을 잇기 위해 설치해야 하는 거울의 갯수

## 🔍 풀이 방법
하나의 C에서 시작하여 bfs를 돌린다. 이때, 방향을 틀어야 하는 경우의 수 = 거울의 수기 때문에, 이전에 사용했던 방향과 이전에 사용했던 거울을 상태로써 저장하기 위해 Node에 저장하였다. visited배열은 방문 x좌표/방문 y좌표/방향 까지 하여 3차원 int 배열로 선언했고, 저장하는 것은 거울의 갯수이다.

## ⏳ 회고
visited배열 설정을 잘못 해서 시간이 좀 더 걸렸다. 이런 유형을 연습할 수 있어서 좋았다.