### PR TITLE
[20240129] BAJ/골드4/N으로 만들기/구범모

### DIFF
--- a/BeommoKoo-dev/202401/29 BAJ 17255 N으로 만들기.md
+++ b/BeommoKoo-dev/202401/29 BAJ 17255 N으로 만들기.md
@@ -1,0 +1,63 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+
+public class b17255 {
+
+    int ans, len;
+    String n;
+    int[] count;
+    Map<String, Integer> map = new HashMap<>();
+
+    private void dfs(int depth, String s) {
+        if(depth == len) {
+            if (s.equals(n)) {
+                ans++;
+            }
+            return;
+        }
+
+        for (int i = 0; i <= 9; i++) {
+            if(count[i] > 0) {
+                count[i]--;
+                String ss = s + Integer.toString(i);
+                String sss = Integer.toString(i) + s;
+                if (ss.equals(sss)) {
+                    dfs(depth + 1, s + Integer.toString(i));
+                }
+                else {
+                    dfs(depth + 1, s + Integer.toString(i));
+                    dfs(depth + 1, Integer.toString(i) + s);
+                }
+                count[i]++;
+            }
+        }
+    }
+
+    private void solution() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = br.readLine();
+        count = new int[10];
+        len = n.length();
+        for (int i = 0; i < len; i++) {
+            int val = n.charAt(i) - '0';
+            count[val]++;
+        }
+
+        dfs(0, "");
+
+        System.out.println(ans);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new b17255().solution();
+    }
+
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17255

## 🧭 풀이 시간
60 분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
수의 양 옆에 숫자를 적어 나가며 최종적으로 N으로 만들 때, N으로 만들 수 있는 방법의 수

## 🔍 풀이 방법
N의 각 정수 갯수를 세준 이후, 그 숫자들만 모두 사용하여 dfs로 탐색하여 경우의 수를 세준다.
중복하는 경우는 다음 dfs로 넘어가기 전에, 문자열끼리 비교해주어 같다면 한번의 dfs만 호출한다.

## ⏳ 회고
