### PR TITLE
[20240129] PRG / LV3 / 입국 심사 / 조재현

### DIFF
--- a/HandamdeCloud/202401/29 PRG 입국 심사.md
+++ b/HandamdeCloud/202401/29 PRG 입국 심사.md
@@ -1,0 +1,24 @@
+```python
+
+def solution(n, times):
+    
+    reverse = sorted(times,reverse=True)
+    times.sort()
+    l = []
+    e_time = sum(times)
+    
+    for i in range(len(times)):
+        k = math.trunc(n*reverse[i]/e_time)
+        l.append(k)
+            
+    remain = n-sum(l)
+
+    for i in range(len(times)):
+        l[i] *= times[i]
+    
+    l[remain-1] += times[remain-1]
+    answer = max(l)
+    
+    return answer
+
+```


### PR DESCRIPTION
## 🧷 문제 링크


## 🧭 풀이 시간
50 분 -> 실패

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
입국심사를 최소시간으로 할 수 있는 방법을 찾아라!

## 🔍 풀이 방법
완전히 수학으로 풀었음
시간을 정방향 역방향으로 정렬하고 분수 비율로 따져서 효율적으로 탐색할 수 있는 시간을 만듦
그리고 계산과정에서 버림된 친구들을 모으면 정수가 됨 => 정수값들을 바탕을로 다시 시간이 가장 덜 소요되는 친구들에게 배분함

## ⏳ 회고
어찌보면 풀이가 완전히 방향성을 빗나간건 맞는 것 같다. 버림된 수를 가지고 다시 재분배하는 과정에서 어떤 입국 담당자가 효율적인지 의사 결정을 쉽게 해낼 수는 없었다. 과정에 확신이 없다보ㄴ 올바른 결과를 찾지 못했는데, 풀이를 보면서 이분탐색에 대해 공부를 많이 하게 되었다.

어떤 상황에 이분탐색 적용이 좋은건지 풀이와 문제를 대입해보면서 생각해봐야할듯 하다.
