### PR TITLE
[20240130] BOJ / 골드5 / 넴모넴모 / 조재현

### DIFF
--- a/HandamdeCloud/202401/30 BOJ 넴모넴모.md
+++ b/HandamdeCloud/202401/30 BOJ 넴모넴모.md
@@ -1,0 +1,31 @@
+```python
+import sys
+input = sys.stdin.readline
+N, M = map(int, input().split())
+square_map = [[0] * (M + 1) for _ in range(N + 1)]
+count = 0
+
+def dfs(x, y):
+    global count
+    if (x, y) == (N + 1, 1):
+        count += 1
+        return
+
+    if y == M:
+        nx, ny = x + 1, 1
+    else:
+        nx, ny = x, y + 1
+
+    # 현재 위치를 넣지 않는 경우
+    dfs(nx, ny)
+
+    # 현재 위치를 사용하는 경우(다만 현재 위치를 기준으로 왼쪽, 위쪽, 좌상단에 넴모가 하나라도 없어야 가능)
+    if square_map[x][y - 1] == 0 or square_map[x - 1][y] == 0 or square_map[x - 1][y - 1] == 0:
+        square_map[x][y] = 1
+        dfs(nx, ny)
+        square_map[x][y] = 0
+
+dfs(1, 1)
+
+print(count)
+```


### PR DESCRIPTION
## 🧷 문제 링크
이전 문제와 동일

## 🧭 풀이 시간
40 분 - 실패

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
넴모를 더이상 탐색할 수 없는 경우의 수를 찾기

## 🔍 풀이 방법
n+1 m+1크기를 만들고 사각형 중 한점이라도 방문하지 않은 상태의 개수를 센다.

## ⏳ 회고
문제를 다시 풀어보아도 쉽게 해답을 찾을 수 없었다.
종료조건, 진행조건에서도 이전 풀이 기억이 있어서 더 탐색을 해보려고 했지만, 조금 어려운 감이 있다.

풀이 자체를 받아들이는게 중요했다. 문제의 진행조건을 판단하는 방법, 탈출 조건이 될 수 있는 방법에 대해서 새로운 변주를 배운 것 같아서 조금 더 문제 해결을 위해서 여러 방법을 찾아봐야할 것 같다.