### PR TITLE
[20240131] PRG / lv3 / 파괴되지 않은 건물 / 박이슬

### DIFF
--- a/Yiseull/202401/31 PRG 파괴되지 않은 건물.md
+++ b/Yiseull/202401/31 PRG 파괴되지 않은 건물.md
@@ -1,0 +1,29 @@
+```python
+def solution(board: list, skill: list) -> int:
+    answer = 0
+    n, m = len(board), len(board[0])
+    skill_board = [[0] * m for _ in range(n)]
+    
+    for type, r1, c1, r2, c2, degree in skill:
+        if type == 1:
+            degree *= -1
+        skill_board[r1][c1] += degree
+        if c2 + 1 < m: skill_board[r1][c2 + 1] -= degree
+        if r2 + 1 < n: skill_board[r2 + 1][c1] -= degree
+        if c2 + 1 < m and r2 + 1 < n: skill_board[r2 + 1][c2 + 1] += degree
+        
+    for i in range(n):
+        for j in range(1, m):
+            skill_board[i][j] += skill_board[i][j - 1]
+            
+    for j in range(m):
+        for i in range(1, n):
+            skill_board[i][j] += skill_board[i - 1][j]
+        
+    for i in range(n):
+        for j in range(m):
+            if board[i][j] + skill_board[i][j] > 0:
+                answer += 1
+            
+    return answer
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/92344

## 🧭 풀이 시간
60분 이상

## ⏳ 시간 복잡도
O(k + n * m), k는 skill의 길이

## 👀 체감 난이도
- [x] 상상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
N x M 크기의 행렬 모양의 게임 맵이 있습니다. 이 맵에는 내구도를 가진 건물이 각 칸마다 하나씩 있습니다. 적은 이 건물들을 공격하여 파괴하려고 합니다. 건물은 적의 공격을 받으면 내구도가 감소하고 내구도가 0이하가 되면 파괴됩니다. 반대로, 아군은 회복 스킬을 사용하여 건물들의 내구도를 높이려고 합니다.

건물의 내구도를 나타내는 2차원 정수 배열 board와 적의 공격 혹은 아군의 회복 스킬을 나타내는 2차원 정수 배열 skill이 매개변수로 주어집니다. 적의 공격 혹은 아군의 회복 스킬이 모두 끝난 뒤 파괴되지 않은 건물의 개수를 return하는 solution함수를 완성해 주세요.

## 🔍 풀이 방법
이 문제는 누적합 말고 다른 풀이로 시도한다면 시간초과가 나는 것 같습니다. 그리고 2차원 배열이기 때문에 누적합도 2차원으로 풀어야 합니다.

예를 들어, [1, 1, 1]에 대해서 0부터 1까지 2만큼의 내구도를 낮추려고 한다면, 최종 결과는 [-1, -1, 1]이 됩니다. 이때 누적합을 사용한다면 [0, 0, 0] 배열에 시작 인덱스에 +내구도, 마지막 인덱스 + 1 에 -내구도를 더하면, [-2, 0, 2]가 되고 시작 인덱스부터 누적합을 하면 [-2, -2, 0]이 됩니다. 그리고 원래의 배열과 합치면 [-1, -1, 0]이 되면서 원하는 결과를 얻을 수 있습니다.

이 방식을 2차원으로 확장하여, skill에 대하여 위와 같이 인덱스에 내구도를 더해놓고, 맨 마지막에 누적합을 계산하면 총 변화값이 나옵니다. 그리고 실제 건물의 내구도와 합하면 원하는 결과를 얻을 수 있습니다.

## ⏳ 회고
이 문제를 처음에 문제 그대로 구현했다가 당연하게 시간초과가 나고, 그 다음 딕셔너리를 사용을 해봐도 똑같이 시간초과가 났습니다. 1시간 넘게 고민하다가 결국 풀이를 봤는데 누적합을 이용해야하는 문제였습니다. 평소 누적합 문제를 많이 풀어보지 않아서 당황했지만 풀이를 보니 금방 이해할 수 있었고, 일주일 뒤에 다시 풀어봐서 제대로 풀이를 이해했는지 확인해볼 예정입니다!