### PR TITLE
[20240202] BAJ/골드5/알약/구범모

### DIFF
--- a/BeommoKoo-dev/202402/02 BAJ 4811 알약.md
+++ b/BeommoKoo-dev/202402/02 BAJ 4811 알약.md
@@ -1,0 +1,61 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class Main {
+
+    int n;
+    long[][] dp;
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        while (true) {
+            n = Integer.parseInt(br.readLine());
+            if (n == 0) {
+                break;
+            }
+            System.out.println(dp[n][0]);
+        }
+    }
+
+    private long dfs(int w, int h) {
+        if (h < 0) {
+            return 0;
+        }
+
+        if (dp[w][h] != -1) {
+            return dp[w][h];
+        }
+
+
+        dp[w][h] = 0;
+
+        dp[w][h] += dfs(w - 1, h + 1) + dfs(w, h - 1);
+
+        return dp[w][h];
+    }
+
+    private void solution() throws IOException {
+        dp = new long[31][31];
+        for (int i = 1; i <= 30; i++) {
+            Arrays.fill(dp[i], -1);
+        }
+        dp[1][0] = 1;
+        for (int i = 1; i <= 30; i++) {
+            dp[0][i] = 1;
+        }
+        dfs(30, 0);
+        input();
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/4811

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
알약을 꺼내 하나 전체를 먹는 경우와 반개를 먹는 경우를 문자열로 적었을 때, 나올 수 있는 경우의 수

## 🔍 풀이 방법
N = 1, 2, 3까지 적어보니 부분문제가 보였고, dp[w][h] : 알약 1개짜리 w개와 반개짜리 h개가 남았을 때의 경우의 수로 정의한 이후 점화식을 세워보니
dp[w][h] = dp[w - 1][h + 1] +dp[w][h - 1]가 나왔다.
dp[n][0]이 내가 구해야 할 것이므로 매 테스트 케이스마다 출력.


## ⏳ 회고
