### PR TITLE
[20240202] BAJ / Gold1 / 외판원 순회 / 강병곤

### DIFF
--- a/Curry4182/202402/02 외판원 순회.md
+++ b/Curry4182/202402/02 외판원 순회.md
@@ -1,0 +1,86 @@
+```java
+
+package net.acmicpc;
+
+import java.util.*;
+
+public class BOJ2098 {
+
+	static int[][] wArr;
+
+	static int N;
+
+	static int fullSet;
+
+	static int MAX_INT = Integer.MAX_VALUE - (int) Math.pow(10, 9);
+
+	static int[][] memory;
+
+	// start를 시작으로 했을 때 set이 맞는가?
+	public static int f(int start, int set) {
+
+		if(set == fullSet) {
+			if(wArr[start][0] == 0) {
+				return MAX_INT;
+			}
+
+			return wArr[start][0];
+		}
+
+		if(memory[start][set] != -1) {
+			return memory[start][set];
+		}
+
+		int ret = MAX_INT;
+
+		for(int next=1; next<N; next++) {
+			if((set & (1 << next)) != 0) {
+				continue;
+			}
+
+			if(wArr[start][next] == 0) {
+				continue;
+			}
+
+			int setContainNext = set | (1 << (next));
+			int result = f(next, setContainNext) + wArr[start][next];
+			ret = Math.min(ret, result);
+		}
+
+		memory[start][set] = ret;
+		return ret;
+	}
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+
+		N = sc.nextInt();
+
+		//
+		memory = new int[N][(int)Math.pow(2,N)];
+
+		// a에서 b로 갔을 때 비용
+		wArr = new int[N][N];
+
+		// 집합에 모든 원소가 채워졌을 때
+		fullSet = (int)Math.pow(2, N) - 1;
+
+		for(int i=0; i<memory.length; i++) {
+			for(int j=0; j<memory[0].length; j++) {
+				memory[i][j] = -1;
+			}
+		}
+
+		for(int i=0; i<N; i++) {
+			for(int j=0; j<N; j++) {
+				wArr[i][j] = sc.nextInt();
+			}
+		}
+
+		int result = f(0, 1);
+		System.out.println(result);
+	}
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2098

## 🧭 풀이 시간
 60분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
어떤 도시a 에서 어떤 도시b 로 가는 모든 비용이 주어졌을 때 모든 도시를 방문하는 최소 비용을 출력하는 문제  

## 🔍 풀이 방법
어떤 도시 a에서 어떤 도시 b로 가는 방법은 n 이고 이후 방법은 n-1이다. 이를 합치면 n! 인데 여기서 다이나믹 프로그래밍과 비트마스킹을 사용하여 O(2^n *n^2) 시간복잡도와 O(2^n * n) 공간 복잡도로 줄일 수 있었다.

## ⏳ 회고
처음 다이나믹 프로그래밍으로 풀려고 했지만 무엇을 어떻게 저장할지 고민을 많이 했다. 
