### PR TITLE
[20240206] BAJ/골드3/벼룩시장/구범모

### DIFF
--- a/BeommoKoo-dev/202402/06 BAJ 14943 벼룩시장.md
+++ b/BeommoKoo-dev/202402/06 BAJ 14943 벼룩시장.md
@@ -1,0 +1,104 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    long ans;
+    int n;
+    Queue<Pair> plusQ = new LinkedList<>();
+    Queue<Pair> minusQ = new LinkedList<>();
+
+    class Pair {
+        int val, idx;
+
+        public Pair(int val, int idx) {
+            this.val = val;
+            this.idx = idx;
+        }
+    }
+
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            int b = Integer.parseInt(st.nextToken());
+            if (b > 0) {
+                plusQ.add(new Pair(b, i));
+            } else if(b < 0) {
+                minusQ.add(new Pair(b, i));
+            }
+        }
+    }
+
+    private void solution() throws IOException {
+        input();
+        Pair p = null;
+        Pair m = null;
+        if (!plusQ.isEmpty()) {
+            p = plusQ.poll();
+        }
+        if (!minusQ.isEmpty()) {
+            m = minusQ.poll();
+        }
+
+        if (p == null || m == null) {
+            System.out.println(ans);
+            return;
+        }
+
+        if (p.val > -m.val) {
+            ans += -m.val * Math.abs(p.idx - m.idx);
+            p.val += m.val;
+            m.val = 0;
+        }
+        else {
+            ans += p.val * Math.abs(p.idx - m.idx);
+            m.val += p.val;
+            p.val = 0;
+        }
+
+        while (true) {
+            if (plusQ.isEmpty() && minusQ.isEmpty()) {
+                break;
+            }
+
+            if (p.val == 0 && (!plusQ.isEmpty())) {
+                p = plusQ.poll();
+            }
+
+            if (m.val == 0 && (!minusQ.isEmpty())) {
+                m = minusQ.poll();
+            }
+
+            if (p.val > -m.val) {
+                ans += -m.val * Math.abs(p.idx - m.idx);
+                p.val += m.val;
+                m.val = 0;
+            }
+
+            else {
+                ans += p.val * Math.abs(p.idx - m.idx);
+                m.val += p.val;
+                p.val = 0;
+            }
+        }
+
+        System.out.println(ans);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/14943

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
벼룩을 사는 사람과 파는 사람이 있을 때, 배달의 최소비용

## 🔍 풀이 방법
사는사람(음수의 가격)과 파는 사람(양수의 가격)을 입력받는 순서대로 각각 다른 큐에 집어넣고,
큐의 front끼리 비교하는 식으로, 최대한 거리가 가까운 사람끼리 거래를 하도록 그리디하게 접근한다.
정당성 증명은 다음과 같다.
만약 -1 1 2 -3 1 이 있다고 해보자. 그리디하게 접근한다면 (-1, 1), (2, -3), (1, -3)이 거래하게 된다. 따라서 답은 1 + 2 + 1 = 4가 된다. (모두 거리가 1)
만약 거리가 가까운 순으로 거래하지 않고 (-1, 2), (1, -3), (2, -3) (1, -3)이 거래한다고 해보자. 그렇다면 1(가격) * 2(거리) + 1 * 2 + 2 * 1 + 1 * 1 = 6이 돼버린다.

## ⏳ 회고
