### PR TITLE
[20240208] BAJ/골드2/퍼즐/구범모

### DIFF
--- a/BeommoKoo-dev/202402/08 BAJ 1525 퍼즐.md
+++ b/BeommoKoo-dev/202402/08 BAJ 1525 퍼즐.md
@@ -1,0 +1,126 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    Set<String> visited = new HashSet<>();
+    int[][] arr = {
+        {1, 3, 100, 100},
+        {0, 2, 4, 100},
+        {1, 5, 100, 100},
+        {0, 4, 6, 100},
+        {1, 3, 5, 7},
+        {2, 4, 8, 100},
+        {3, 7, 100, 100},
+        {6, 4, 8, 100},
+        {7, 5, 100, 100}
+    };
+
+    class Node {
+        String map;
+        int count;
+
+        public Node(String map, int count) {
+            this.map = map;
+            this.count = count;
+        }
+    }
+
+    private boolean isInRange(int x) {
+        if (x < 0 || x > 8) {
+            return false;
+        }
+        return true;
+    }
+
+    private int check(String s) {
+        if (visited.contains(s)) {
+            return -1;
+        }
+
+        boolean flag = true;
+        for (int i = 1; i < 9; i++) {
+            if (s.charAt(i - 1) - '0' != i) {
+                flag = false;
+            }
+        }
+        // 정답
+        if(flag) {
+            return 1;
+        }
+        visited.add(s);
+        return 0;
+    }
+
+    private String swap(String s, int a, int b) {
+        char[] c = s.toCharArray();
+        char tmp = c[a];
+        c[a] = c[b];
+        c[b] = tmp;
+
+        return new String(c);
+    }
+
+    private void solution() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String s = "";
+        for (int i = 0; i < 3; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < 3; j++) {
+                s += st.nextToken();
+            }
+        }
+        if (check(s) == 1) {
+            System.out.println(0);
+            return;
+        }
+        Queue<Node> q = new LinkedList<>();
+        q.add(new Node(s, 0));
+        while (!q.isEmpty()) {
+            Node nd = q.poll();
+            String map = nd.map;
+            int count = nd.count;
+            int idx = 0;
+
+            for (int i = 0; i < 9; i++) {
+                int val = map.charAt(i) - '0';
+                if (val == 0) {
+                    idx = i;
+                    break;
+                }
+            }
+
+            for (int i = 0; i < 4; i++) {
+                int nextVal = arr[idx][i];
+                if (!isInRange(nextVal)) {
+                    continue;
+                }
+                String nMap = swap(map, idx, nextVal);
+                int ret = check(nMap);
+                if (ret == 1) {
+                    System.out.println(count + 1);
+                    return;
+                } else if (ret == 0) {
+                    q.add(new Node(nMap, count + 1));
+                }
+            }
+        }
+        System.out.println(-1);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1525

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
임의로 배정된 퍼즐을 잘 옮겨서 문제에서 주어진 모양대로 만들 때, 최소 이동횟수

## 🔍 풀이 방법
최소 이동횟수를 구해야 하므로 bfs를 채택. 각 퍼즐의 상태를 어떻게 나타낼까 하다가 하나의 노드를 2차원 int배열로 선정하려 했었다.
하지만 문제의 메모리 제한은 32MB라, 계산해보니 최악의 경우 메모리 제한을 살짝 넘기는 정도라, 하나의 노드의 36바이트가 드는 2차원 int배열이(3x3배열이므로) 아닌, String으로 하나의 노드를 표현했다.(9바이트)
이후 String에서 0을 찾아 0의 주위와 바꾸어 보고, 해당 String이 만들어진 적 없으면 set에 해당 string을 넣어서 방문표시를 해주었다.

## ⏳ 회고
색다른 bfs라 좋았다.