### PR TITLE
[20240213] BAJ/골드3/마라톤2/구범모

### DIFF
--- a/BeommoKoo-dev/202402/13 BAJ 10653 마라톤2.md
+++ b/BeommoKoo-dev/202402/13 BAJ 10653 마라톤2.md
@@ -1,0 +1,66 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    int n, k, ans = Integer.MAX_VALUE;
+    int[][] arr, dp;
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+        k = Math.min(k, n - 2);
+        arr = new int[n + 1][2];
+        dp = new int[n + 1][k + 1];
+        for (int i = 1; i <= n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < 2; j++) {
+                arr[i][j] = Integer.parseInt(st.nextToken());
+            }
+            Arrays.fill(dp[i], Integer.MAX_VALUE);
+        }
+    }
+
+    private void solution() throws IOException {
+        input();
+        // n번째 체크포인트는 제외
+        dp[1][0] = 0;
+        dp[2][0] = Math.abs(arr[2][0] - arr[1][0]) + Math.abs(arr[2][1] - arr[1][1]);
+        for (int i = 3; i <= n; i++) {
+            for (int j = 1; j < i; j++) {
+                int skipped = i - j - 1;
+                for (int l = 0; l <= k; l++) {
+                    if (l + skipped <= k && dp[j][l] != Integer.MAX_VALUE) {
+                        int diff = Math.abs(arr[i][0] - arr[j][0]) + Math.abs(arr[i][1] - arr[j][1]);
+                        dp[i][l + skipped] = Math.min(dp[i][l + skipped], dp[j][l] + diff);
+                    }
+                    // if (dp[j][l] != Integer.MAX_VALUE) {
+                    //     dp[i][l + 1] = Math.min(dp[i][l + 1], dp[j][l]);
+                    // }
+                }
+            }
+        }
+
+        for (int i = 0; i <= k; i++) {
+            ans = Math.min(ans, dp[n][i]);
+        }
+        System.out.println(ans);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/10653

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
1번부터 n번 체크포인트까지 최대 k개를 스킵하여 도달할 때, 드는 최소 거리

## 🔍 풀이 방법
처음에는 그리디 접근방식으로 각 체크포인트간에 거리가 먼 것들을 제외했으나, 그렇게 되면 제외한 점 앞뒤로 다시 연결시켜 주어야 하기에 복잡해진다. 알고리즘 태그를 보니 dp여서 다시 생각해 보니 상태 정의 해야할 것들이 크게 현재 인덱스, 몇개 체크포인트를 건너뛰었는지를 저장하여 bottom up으로 쌓아나갔다.

## ⏳ 회고
문제를 풀 때 알고리즘의 정당성을 어느정도 증명해보고 풀이를 하는 습관을 가지자.