### PR TITLE
[20240213] BAJ / 실버4 / Project Teams / 신예진

### DIFF
--- a/born-A/202402/13 BAJ Projec Teams.md
+++ b/born-A/202402/13 BAJ Projec Teams.md
@@ -1,0 +1,39 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main{
+    
+    public static void main(String [] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringBuilder sb = new StringBuilder();
+        static final int NUMBER_OF_TEAM = Integer.parseInt(br.readLine());
+        static int member[] = new int [NUMBER_OF_TEAM * 2];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        for(int i=0;i < NUMBER_OF_TEAM * 2; i++) {
+            member[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        Arrays.sort(member);
+        int min = 200000;
+        
+        for(int i=0;i<NUMBER_OF_TEAM;i++) {
+            int teamScore = member[i] + member[NUMBER_OF_TEAM*2-1-i];
+            
+            if(teamScore < min) {
+                min = teamScore;
+            }
+        }
+        
+        sb.append(min);
+        sb.append("\n"); 
+        
+        bw.write(sb.toString());
+        
+        bw.flush();
+        br.close();
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/20044 

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
2n명의 학생숫가 주어지고, n개의 팀의 점수의 합을 만든다.
팀의 점수의 합이 되는 수를 구한다.

## 🔍 풀이 방법
정렬한 후, 차이를 최소화 하기 위해 (1,n), (2,n-1), (3,n-2) 식으로 쌍을 만든다.
쌍의 점수의 합이 최소가 되는 값을 구한다.

## ⏳ 회고
