### PR TITLE
[20240214] BAJ / 골드5 / 최소 회의실 개수 / 박이슬

### DIFF
--- a/Yiseull/202402/14 BAJ 최소 회의실 개수.md
+++ b/Yiseull/202402/14 BAJ 최소 회의실 개수.md
@@ -1,0 +1,28 @@
+```python
+from heapq import *
+import sys
+input = sys.stdin.readline
+
+
+def solution(n: int, meetings: list) -> int:
+    answer, room = 0, 0
+    ongoing = []
+    meetings.sort()
+    for meeting in meetings:
+        while ongoing and ongoing[0] <= meeting[0]:
+            heappop(ongoing)
+            room += 1
+        if room == 0:
+            answer += 1
+            room += 1
+        heappush(ongoing, meeting[1])
+        room -= 1
+
+    return answer
+
+
+if __name__ == '__main__':
+    n = int(input())
+    meetings = [tuple(map(int, input().split())) for _ in range(n)]
+    print(solution(n, meetings))
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/19598

## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
서준이는 아빠로부터 N개의 회의를 모두 진행할 수 있는 최소 회의실 개수를 구하라는 미션을 받았다. 각 회의는 시작 시간과 끝나는 시간이 주어지고 한 회의실에서 동시에 두 개 이상의 회의가 진행될 수 없다. 단, 회의는 한번 시작되면 중간에 중단될 수 없으며 한 회의가 끝나는 것과 동시에 다음 회의가 시작될 수 있다. 회의의 시작 시간은 끝나는 시간보다 항상 작다. N이 너무 커서 괴로워 하는 우리 서준이를 도와주자.

## 🔍 풀이 방법
풀이 방법은 간단하다. 아래 아이디어를 구현하기만 하면 된다.
1. 회의 시간을 시작 시간으로 정렬한다.
2. 다음 회의가 시작되기 전, 종료된 회의가 있는지 확인하고 종료된 회의가 있으면 회의실을 반납한다.
3. 남은 회의실 개수를 확인해서 남아있으면 배정하고, 없다면 회의실을 하나 더 추가해서 배정한다.

약간의 고민 포인트는 회의 시간을 시작 시간으로 정렬하는 것과 회의의 종료 시간을 우선순위 큐에 저장하는 것이다.

## ⏳ 회고
사실 이 문제의 유형은 나에게 되게 익숙한 유형이다. 학교 다닐 때 알고리즘 수업으로 구간 그래프의 정점 채색에 대해서 배웠는데 그때 수업을 되게 열심히 들었었다. 그래서 정점 채색 유형은 되게 익숙한만큼 나에게 비교적 쉬운 편의 문제이다. 