### PR TITLE
[20240216] BAJ/골드4/리조트/구범모

### DIFF
--- a/BeommoKoo-dev/202402/16 BAJ 13302 리조트.md
+++ b/BeommoKoo-dev/202402/16 BAJ 13302 리조트.md
@@ -1,0 +1,73 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    int n, m, ONE = 10000, THREE = 25000, FIVE = 37000;
+    int[][] dp;
+    boolean[] rest;
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        dp = new int[n + 1][3 * n + 1];
+        rest = new boolean[n + 1];
+        if (m != 0) {
+            st = new StringTokenizer(br.readLine());
+        }
+        for (int i = 0; i <= n; i++) {
+            Arrays.fill(dp[i], Integer.MAX_VALUE);
+        }
+        for (int i = 1; i <= m; i++) {
+            int day = Integer.parseInt(st.nextToken());
+            rest[day] = true;
+        }
+    }
+
+    private void solution() throws IOException {
+        input();
+        dp[0][0] = 0;
+        // 쉬는날, 안쉬는날 구분을 해야하나?
+        for (int i = 1; i <= n; i++) {
+            for (int j = 0; j <= 3 * n; j++) {
+                if (dp[i - 1][j] != Integer.MAX_VALUE) {
+                    dp[i][j] = Math.min(dp[i][j], dp[i - 1][j] + ONE);
+                }
+                if (i - 3 >= 0 && j - 1 >= 0 && dp[i - 3][j - 1] != Integer.MAX_VALUE) {
+                    dp[i][j] = Math.min(dp[i][j], dp[i - 3][j - 1] + THREE);
+                }
+                if (i - 5 >= 0 && j - 2 >= 0 && dp[i - 5][j - 2] != Integer.MAX_VALUE) {
+                    dp[i][j] = Math.min(dp[i][j], dp[i - 5][j - 2] + FIVE);
+                }
+                // 쿠폰 사용
+                if (j + 3 <= 3 * n && dp[i - 1][j + 3] != Integer.MAX_VALUE) {
+                    dp[i][j] = Math.min(dp[i][j], dp[i - 1][j + 3]);
+                }
+                // 쉬는날
+                if (rest[i]) {
+                    dp[i][j] = Math.min(dp[i][j], dp[i - 1][j]);
+                }
+            }
+        }
+        int ans = Integer.MAX_VALUE;
+        for (int i = 0; i <= 3 * n; i++) {
+            ans = Math.min(ans, dp[n][i]);
+        }
+        System.out.println(ans);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13302

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
n일 중 m일을 쉬고, 리조트의 하루/3일/5일 이용권의 금액과 각 이용권을 구매했을 때의 지급되는 쿠폰이 있을 때,
m일을 제외한 모든 날을 리조트를 대여했을 때의 최소 금액을 구해라.

## 🔍 풀이 방법
brute force는 O(3^100)이 나오므로, dp로 연산을 줄였다.
저장돼야 하는 상태는
1. 날짜, 2. 쿠폰의 갯수이므로,
dp[i][j] : i일에 리조트를 대여한 상태이고, 쿠폰이 j개 남아 있을 때 예약금의 (누적)최솟값으로 정의하고 점화식을 도출하였다.

## ⏳ 회고
