### PR TITLE
[20240219] BAJ / 실버3 / 개으른 백곰 / 박이슬

### DIFF
--- a/Yiseull/202402/19 BAJ 게으른 백곰.md
+++ b/Yiseull/202402/19 BAJ 게으른 백곰.md
@@ -1,0 +1,26 @@
+```python
+import sys
+input = sys.stdin.readline
+
+
+def solution(n: int, k: int, ice: list, min_x: int, max_x: int) -> int:
+    k *= 2
+    ice_sum = [0] * 1000001
+    if min_x + k > 1000000:
+        return sum(ice[min_x:])
+    ice_sum[min_x + k] = sum(ice[min_x:min_x + k + 1])
+    for i in range(min_x + k + 1, max_x + 1):
+        ice_sum[i] = ice_sum[i - 1] - ice[i - k - 1] + ice[i]
+    return max(ice_sum[min_x + k:max_x + 1])
+
+
+if __name__ == '__main__':
+    n, k = map(int, input().split())
+    ice = [0] * 1000001
+    min_x, max_x = 1000001, 0
+    for _ in range(n):
+        g, x = map(int, input().split())
+        ice[x] = g
+        min_x, max_x = min(min_x, x), max(max_x, x)
+    print(solution(n, k, ice, min_x, max_x))
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/10025

## 🧭 풀이 시간
45분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
앨버트가 가장 적은 거리만 움직이고도 최대한 많은 얼음으로 더위를 식힐 수 있도록 도와주자. 우리 안은 1차원 배열로 생각하며, 총 N(1 ≤ N ≤ 100000)개의 얼음 양동이들이 xi(0 ≤ xi ≤ 1,000,000)좌표마다 놓여 있고 각 양동이 안에는 gi(1 ≤ gi ≤ 10,000)씩의 얼음이 들어 있다. 일단 앨버트가 자리를 잡으면 그로부터 좌우로 K(1 ≤ K ≤ 2,000,000) 만큼 떨어진 양동이까지 닿을 수 있다. 앨버트는 양동이가 놓여 있는 자리에도 자리잡을 수 있다. 모든 얼음 양동이의 위치는 다르다.

앨버트가 최적의 자리를 골랐을 때 얼음의 합을 구하시오. 즉, 얼음들의 합의 최댓값을 구해야 한다.

## 🔍 풀이 방법
풀이는 슬라이딩 윈도우와 누적합을 사용하는 것이다. 먼저 풀이는 다음과 같이 간단하다.
1. 얼음이 들어있는 최소 인덱스부터 최대 인덱스까지 k*2 길이의 얼음들의 양을 업데이트 하는데, 
2. 한 칸씩 이동하면서 누적합에 i번째 얼음은 추가하고, i - (k*2) - 1번째 얼음은 제거한다.

이때 주의해야할 점은, (최소 인덱스 + K*2)가  1,000,000를 넘는지 확인해줘야 한다. 만약 넘는다면 배열의 최대 인덱스는 1,000,000여서 인덱스 에러가 발생한다. 따라서  1,000,000을 넘는 경우에는 최소 인덱스부터 마지막 인덱스까지의 길이가 k*2 미만이라는 것을 의미함으로 입력받은 전체 얼음의 양을 모두 합해서 반환하면 된다.

## ⏳ 회고
풀이는 이렇게 간단하지만 푸는 데 오래 걸렸다. 그 이유는 인덱스의 범위를 설정하는 데 어려움을 겪었기 때문이다.
나는 연산의 범위를 최소화 하기 위해 얼음이 주어진 최소 인덱스와 최대 인덱스를 따로 구해서 이 범위 내에서만 연산을 진행했는데 이때 어디까지 연산을 진행해야 하는지 정확한 범위를 구하는 데 복잡함을 느꼈다. 또한 (최소 인덱스 + K*2)가  1,000,000를 넘는지 확인하는 것을 나중에 알아차려서 계속 실패가 떴었다.

항상 예외 케이스에 대해서 생각하자💡