### PR TITLE
[20240221] PRG / lv2 / 순위 검색 / 박이슬

### DIFF
--- a/Yiseull/202402/21 PRG 순위 검색.md
+++ b/Yiseull/202402/21 PRG 순위 검색.md
@@ -1,0 +1,27 @@
+```python
+from bisect import bisect_left
+from collections import defaultdict
+
+
+def solution(info, query):
+    answer = []
+    info_dict = defaultdict(list)
+    
+    for i in info:
+        data = i.split()
+        for lang in (data[0], '-'):
+            for job in (data[1], '-'):
+                for career in (data[2], '-'):
+                    for food in (data[3], '-'):
+                        info_dict[(lang, job, career, food)].append(int(data[4]))
+                        
+    for key in info_dict.keys():
+        info_dict[key].sort()
+    
+    for q in query:
+        lang, job, career, food = q.split(' and ')
+        food, score = food.split()
+        answer.append(len(info_dict[(lang, job, career, food)]) - bisect_left(info_dict[(lang, job, career, food)], int(score)))
+    
+    return answer
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/72412

## 🧭 풀이 시간
75분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
- 코딩테스트 참여 개발언어 항목에 cpp, java, python 중 하나를 선택해야 합니다.
- 지원 직군 항목에 backend와 frontend 중 하나를 선택해야 합니다.
- 지원 경력구분 항목에 junior와 senior 중 하나를 선택해야 합니다.
- 선호하는 소울푸드로 chicken과 pizza 중 하나를 선택해야 합니다.

지원자가 지원서에 입력한 4가지의 정보와 획득한 코딩테스트 점수를 하나의 문자열로 구성한 값의 배열 info, 개발팀이 궁금해하는 문의조건이 문자열 형태로 담긴 배열 query가 매개변수로 주어질 때,
각 문의조건에 해당하는 사람들의 숫자를 순서대로 배열에 담아 return 하도록 solution 함수를 완성해 주세요.

query의 각 문자열은 "[조건] X" 형식입니다. 예를 들면, "cpp and - and senior and pizza 500"은 "cpp로 코딩테스트를 봤으며, 경력은 senior 이면서 소울푸드로 pizza를 선택한 지원자 중 코딩테스트 점수를 500점 이상 받은 사람은 모두 몇 명인가?"를 의미합니다.

## 🔍 풀이 방법
1️⃣ 첫 번째 풀이 - 실패
- 개발언어, 직군, 경력구분, 소울푸드는 dict에 [선택 항목: {지원자 index}] 형태로 저장한다. 코딩테스트 점수는 [지원자 index: 점수] 형태로 저장한다.
- query에 대해서 개발언어, 직군, 경력구분, 소울푸드를 & 연산하여 교집합을 구해주고, 구한 지원자 index에 대해서 한 명씩 확인하며 코딩테스트 점수가 query에서 주어진 점수보다 높은지 확인하며 그 수를 count 해준다.

👉 정확성 테스트는 모두 통과하지만, 효율성 테스트에서 모두 실패한다. 코딩테스트 점수를 일일이 비교하여 count 해주는 연산이 for문으로 돌기 때문에 시간을 많이 소모한다. 이진 탐색으로 계산하는 방법을 생각해봤으나 좋은 해결책을 떠올리지 못했다.

2️⃣ 두 번째 풀이 - 성공
- 지원자가 선택하는 개발언어, 직군, 경력구분, 소울푸드를 key 값으로 하고 코딩테스트 점수를 value로 하는 dict를 만든다. 이때 query의 '-'를 고려하여 선택 항목과 '-'를 모두 가지도록 key 값을 만든다. 예를 들면, "java backend junior chicken 500"을 가진 지원자가 있으면, 개발언어는 java or '-' 를 가지도록 [('java', '-', 'junior', '-': 500] 이런 식으로 총 16가지를 만든다.
- 위에서 만든 dict에 대해 key값마다 코딩테스트 점수로 정렬한다.
- query에서 주어진 쿼리를 key 값으로 하고, 코딩테스트 점수를 이진탐색으로 찾아서 그 수를 반환한다.

## ⏳ 회고
효율성 테스트가 있는 문제들은 항상 첫 번째 생각한 풀이들이 틀리는 것 같다.. 당연히 그렇게 쉽게 냈을리가 없지!!🤔
이런 문제들은 특히나 시간복잡도를 미리 구해놓고 풀이에 들어가는 게 좋다. 안그러면 다 풀어놓고 시간초과 나서 다른 풀이를 새로 떠올려야 한다😭