### PR TITLE
[20240223] PRG / lv3 / 길 찾기 게임 / 박이슬

### DIFF
--- a/Yiseull/202402/23 PRG 길 찾기 게임.md
+++ b/Yiseull/202402/23 PRG 길 찾기 게임.md
@@ -1,0 +1,25 @@
+```python
+import sys
+sys.setrecursionlimit(10000)
+
+
+def solution(nodeinfo: list) -> list:
+    answer = [[], []]
+    nodeinfo = sorted([node + [i + 1] for i, node in enumerate(nodeinfo)])
+    
+    def order(nodeinfo: list):
+        if nodeinfo:
+            root = 0
+            for i, node in enumerate(nodeinfo):
+                if nodeinfo[root][1] < node[1]:
+                    root = i
+
+            answer[0].append(nodeinfo[root][2])
+            order(nodeinfo[:root])
+            order(nodeinfo[root+1:])
+            answer[1].append(nodeinfo[root][2])
+        
+    order(nodeinfo)
+        
+    return answer
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/42892

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
곤경에 빠진 카카오 프렌즈를 위해 이진트리를 구성하는 노드들의 좌표가 담긴 배열 nodeinfo가 매개변수로 주어질 때,
노드들로 구성된 이진트리를 전위 순회, 후위 순회한 결과를 2차원 배열에 순서대로 담아 return 하도록 solution 함수를 완성하자.

#### 제한 사항
- nodeinfo는 이진트리를 구성하는 각 노드의 좌표가 1번 노드부터 순서대로 들어있는 2차원 배열이다.
- nodeinfo의 길이는 1 이상 10,000 이하이다.
- nodeinfo[i] 는 i + 1번 노드의 좌표이며, [x축 좌표, y축 좌표] 순으로 들어있다.
- 모든 노드의 좌표 값은 0 이상 100,000 이하인 정수이다.
- 트리의 깊이가 1,000 이하인 경우만 입력으로 주어진다.
- 모든 노드의 좌표는 문제에 주어진 규칙을 따르며, 잘못된 노드 위치가 주어지는 경우는 없다.

## 🔍 풀이 방법
1. 노드가 입력된 순으로 번호를 갖기 때문에 노드 정보 맨 마지막에 노드 번호까지 추가해서 새롭게 배열을 만들고, x좌표 순으로 정렬한다.
2. y좌표가 가장 큰 노드가 루트 노드이기 때문에, 루트 노드를 찾고 루트 노드를 기준으로 왼쪽 이진트리와 오른쪽 이진트리로 나눈다.
3. 왼쪽 이진트리와 오른쪽 이진트리에 대해서도 2번을 실행한다. (재귀)
4. 문제에서 전위 순회와 후위 순회에 대해서 구하는 것이므로, 전위순회는 3번 전에 정답에 현재 루트를 추가하고, 후위순회는 3번이 다 끝난 후 추가한다.

## ⏳ 회고
이 문제는 전에 풀었던 문제이다. 그때는 오랫동안 풀지 못해서 결국 정답을 보았었다. 시간이 지나고 다시 한 번 풀어보니 어떻게 풀어야하는지는 바로 알 수 있었으나 재귀 호출 때문에 한 번에 정답을 맞추진 못했다. 파이썬은 기본적으로 최대 1000번의 재귀 호출이 가능하다고 한다. 이 점을 앞으로는 까먹지 말고 기억해서 다음 문제 풀 때 써먹자!!