### PR TITLE
[20240228] BAJ / 실버1 / 케빈 베이컨의 6단계 법칙 / 신예진

### DIFF
--- a/born-A/202402/28 BAJ 케빈 베이컨의 6단계 법칙.md
+++ b/born-A/202402/28 BAJ 케빈 베이컨의 6단계 법칙.md
@@ -1,0 +1,62 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static int[][] graph;
+    public static final int INF = 987654321;
+    
+    public static void main(String[] args) throws NumberFormatException,IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        
+        st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        graph = new int[n+1][n+1];
+        
+        for(int i = 1; i < n+1; i++) {
+            for(int j = 1; j < n+1; j++) {
+                graph[i][j] = INF;
+                if(i == j) graph[i][j] = 0;
+            }
+        }
+        
+        for(int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            
+            graph[a][b] = 1;
+            graph[b][a] = 1;
+        }
+        
+        for(int k = 1; k < n+1; k++) {
+            for(int a = 1; a < n+1; a++) {
+                for(int b= 1; b < n+1; b++) {
+                    if(graph[a][b] > graph[a][k] + graph[k][b]){
+                        graph[a][b] = graph[a][k] + graph[k][b];
+                    }
+                }
+            }
+        }
+        
+        int res = INF;
+        int idx = 0;
+        for(int i = 1; i < n+1; i++){
+            int total = 0;
+            for(int j = 1; j < n+1; j++){
+                total += graph[i][j];
+            }
+            
+            if(res > total){
+                res = total;
+                idx = i;
+            }
+        }
+        
+        System.out.print(idx);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1389

## 🧭 풀이 시간
35분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
케빈 베이컨은 미국 헐리우드 영화배우들 끼리 케빈 베이컨 게임을 했을때 나오는 단계의 총 합이 가장 적은 사람을 구하는 문제.

1 3
1 4
4 5
4 3
3 2
가 주어졌을 때,

1은 2까지 3을 통해 2단계 만에, 3까지 1단계, 4까지 1단계, 5까지 4를 통해서 2단계 만에 알 수 있다. 따라서, 케빈 베이컨의 수는 2+1+1+2 = 6이다.
2는 1까지 3을 통해서 2단계 만에, 3까지 1단계 만에, 4까지 3을 통해서 2단계 만에, 5까지 3과 4를 통해서 3단계 만에 알 수 있다. 따라서, 케빈 베이컨의 수는 2+1+2+3 = 8이다.
3은 1까지 1단계, 2까지 1단계, 4까지 1단계, 5까지 4를 통해 2단계 만에 알 수 있다. 따라서, 케빈 베이컨의 수는 1+1+1+2 = 5이다.
4는 1까지 1단계, 2까지 3을 통해 2단계, 3까지 1단계, 5까지 1단계 만에 알 수 있다. 4의 케빈 베이컨의 수는 1+2+1+1 = 5가 된다.

## 🔍 풀이 방법
플로이드 워셜 

## ⏳ 회고
