### PR TITLE
[20240229] PRG / lv3 / 징검다리 건너기 / 강병곤

### DIFF
--- a/Curry4182/202402/29 징검다리 건너기.md
+++ b/Curry4182/202402/29 징검다리 건너기.md
@@ -1,0 +1,24 @@
+```python
+
+import heapq
+
+def solution(stones, k):
+    answer = float('inf')
+    
+    pq = []
+    for idx, stone in enumerate(stones[:k]):
+        heapq.heappush(pq, (-stone, idx))
+    
+    answer = min(answer, -pq[0][0]) 
+    
+    for i in range(k, len(stones)):
+        heapq.heappush(pq, (-stones[i], i))
+        while pq[0][1] <= i-k:
+            heapq.heappop(pq)
+        answer = min(answer, -pq[0][0]) 
+    
+    return answer
+
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/64062?language=python3

## 🧭 풀이 시간
120분

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
한 번 돌을 건널 때 마다 배열의 모든 값이 1씩 떨어진다.
그리고 원소의 값이 0일 때 그 원소는 건널 수 없다.
최대 k까지 건너뛸 수 있을 때 최대 몇번 건너뛸 수 있는지 출력한다.


## 🔍 풀이 방법
슬라이딩 윈도우
- 슬라이딩 윈도우 방식으로 k개 중에 max를 구한다.
- 전체 max중 최소 값을 출력한다.
- 원소가 1씩 증가할 때 마다 새로운 원소를 추가하고 기존 원소를 제거해야 한다.
- 이 때 TreeSet을 사용하면배열의 길이가 n일 때 n log n으로 만족시킬 수 있ek.
- 전체 배열의 길이가 20 * 10^5 임으로 가능하다고 생각하였지만 java는 통과가 안되었고 python으로 변경해보니 통과하였다.

이분탐색
- 이 방법은 자바도 가능하다.
- 문제에서 요구하는 값을 x 라고 하자
- x를 만족하는지 확인하는데 배열의 길이 n 만큼 시간복잡도가 든다.
- x가 통과되면 늘리고 통과되지 않으면 좀 더 줄이는 방식으로 구할 때 이분탐색으로 한다면 log n의 시간 복잡도가 든다.
- 그러면 전체 n log n으로 통과된다.
- 이분탐색이 되는 이유는 java는 idx 와 value를 저장하기 위해 long으로 변경하는데 이때 발생하는 오버헤드 때문에 안되는것으로 보인다. 


## ⏳ 회고
