### PR TITLE
[20240304] BAJ/골드5/피자 굽기/구범모

### DIFF
--- a/BeommoKoo-dev/202403/04 1756 피자 굽기.md
+++ b/BeommoKoo-dev/202403/04 1756 피자 굽기.md
@@ -1,0 +1,70 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Stack;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    int d, n, cur, ans;
+    int[] arr, arr2;
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        d = Integer.parseInt(st.nextToken());
+        n = Integer.parseInt(st.nextToken());
+        arr = new int[d + 2];
+        arr2 = new int[n + 1];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= d; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        arr[d + 1] = -1;
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= n; i++) {
+            arr2[i] = Integer.parseInt(st.nextToken());
+        }
+    }
+
+    private void solution() throws IOException {
+        input();
+        for (int i = 1; i <= d; i++) {
+            if (arr[i + 1] < arr2[1] && arr[i] >= arr2[1]) {
+                cur = i;
+                break;
+            }
+        }
+
+        for (int i = 1; i < d; i++) {
+            arr[i + 1] = Math.min(arr[i + 1], arr[i]);
+        }
+
+        for (int i = 1; i <= n; i++) {
+            boolean flag = false;
+            while (true) {
+                if (cur == 0 || flag) {
+                    break;
+                }
+                if (arr[cur] >= arr2[i]) {
+                    if (i == n) {
+                        ans = cur;
+                    }
+                    flag = true;
+                }
+                cur--;
+            }
+        }
+        System.out.println(ans);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1756

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
틀의 지름에 맞추어 피자반죽을 넣을 때, 가장 마지막에 들어가는 피자반죽의 위치를 구하시오.

## 🔍 풀이 방법
완전탐색으로 돌리면 O(ND)가 나와 시간초과가 뜬다.
어떤 위치에 피자를 넣으면 그것보다 더 깊은곳에는 못 넣기 때문에, 하나의 포인터를 두어 최대 D만큼만 움직이게 하여 시간복잡도를 O(N+D)로 개선할 수 있다. 이때 주의해야 할 점은, 틀의 지름이 5 4 6 2 3 이런식으로 되면, 현재 틀의 지름을 이전의 틀의 지름 중 최솟값으로 만드는 작업이 필요하므로, 5 4 4 2 2로 틀의 지름을 바꾼 이후에 틀의 맨 끝에서부터 피자반죽을 넣어본다.

## ⏳ 회고
시간복잡도 개선하는 면에서 하나 배워가면 좋을 것 같다.