### PR TITLE
[20240305] PRG / lv3 / 기지국 설치 / 박이슬

### DIFF
--- a/Yiseull/202403/05 PRG 기지국 설치.md
+++ b/Yiseull/202403/05 PRG 기지국 설치.md
@@ -1,0 +1,16 @@
+```python
+from math import ceil
+
+
+def solution(n: int, stations: list, w: int) -> int:
+    ww = w * 2 + 1
+    answer = 0
+    current = 1
+    for station in stations:
+        if current < station - w:
+            answer += ceil((station - w - current) / ww)
+        current = station + w + 1
+    answer += ceil((n - current + 1) / ww)
+        
+    return answer
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/12979#

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
전파의 도달 거리가 W일 땐, 기지국이 설치된 아파트를 기준으로 전파를 양쪽으로 W만큼 전달할 수 있습니다.

아파트의 개수 N, 현재 기지국이 설치된 아파트의 번호가 담긴 1차원 배열 stations, 전파의 도달 거리 W가 매개변수로 주어질 때, 모든 아파트에 전파를 전달하기 위해 증설해야 할 기지국 개수의 최솟값을 리턴하는 solution 함수를 완성해주세요

## 🔍 풀이 방법
- 전파의 도달 거리가 w라고 하면, 하나의 기지국에서 총 w*2+1 만큼의 전파를 전달할 수 있다.
- 기지국의 전파를 받지 않는 곳의 연속된 길이가 d라고 한다면, 설치해야하는 최소 기지국의 개수는 d / (w*2+1)의 올림값이 될 것이다. 예를 들면, d가 5이고, w가 1이라고 한다면, w*2+1는 3이므로 최소 2개의 기지국을 설치해야 모든 곳에 전파를 전달할 수 있다.
```python
def solution(n: int, stations: list, w: int) -> int:
    ww = w * 2 + 1
    answer = 0
    current = 1
    for station in stations:
        if current < station - w:
            answer += ceil((station - w - current) / ww)
        current = station + w + 1
    answer += ceil((n - current + 1) / ww)
        
    return answer
```

## ⏳ 회고
전파가 터지지 않는 곳의 길이를 구하기 위해 기지국 사이의 길이를 구했다. 이때 마지막 아파트까지 고려한다고 stations에 무작정 n을 append해서 틀렸다. 생각을 해보니 stations에 추가하면 마지막 아파트에는 무조건 기지국이 있다는 조건으로 정답을 구하게 될 것이다. 당연하게 틀린 방식이었지만 처음에는 캐치하지 못하고 헤맸었다. 그러다 결국 틀린 것을 알았고 마지막 아파트는 따로 처리해주어 통과할 수 있었다. 

이 문제도 주어진 2개의 테스트 케이스만 통과해서 제출하면 맞을 거라고 생각했다. 하지만 틀렸고 잘못된 점을 고쳐서 결국은 통과할 수 있었지만 실제 코테였다면 결과가 주어지지 않기 때문에 최종적으로 틀렸을 것이다. 항상 생각하는 거지만 주어진 테스트 케이스 이외에 여러 케이스들을 생각해야 하고, 내 풀이가 한 번에 맞을거라는 확신은 버려야 한다.