### PR TITLE
[20240305] BAJ / 실버5 / 직사각형 네개의 합집합의 면적 구하기 / 신예진

### DIFF
--- a/born-A/202403/05 BAJ 직사각형 네개의 합집합의 면적 구하기.md
+++ b/born-A/202403/05 BAJ 직사각형 네개의 합집합의 면적 구하기.md
@@ -1,0 +1,43 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Solution {
+	static int maxIndex = 100;
+	static int[][] arr = new int[maxIndex][maxIndex];
+	
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+  
+        for(int i = 0; i < 4; i++) {
+        	StringTokenizer st = new StringTokenizer(br.readLine());
+	        int x1 = Integer.parseInt(st.nextToken());
+	        int y1 = Integer.parseInt(st.nextToken());
+	        int x2 = Integer.parseInt(st.nextToken());
+	        int y2 = Integer.parseInt(st.nextToken());
+	        
+	        Square(x1,y1,x2,y2);
+        }
+        
+        System.out.println(sum());
+    }
+    
+    public static void Square(int x1, int y1, int x2, int y2) {
+    	for(int i = x1; i < x2; i++) {
+    		for(int j = y1; j < y2; j++) {
+    			arr[i][j] = 1;
+    		}
+    	}
+    }
+    
+    public static int sum() {
+    	int sum = 0;
+        for(int i = 0; i < maxIndex; i++) {
+        	for(int j = 0; j < maxIndex; j++) {
+        		sum += arr[i][j];
+        	}
+        }
+        return sum;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/submit/2669

## 🧭 풀이 시간
20분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
네 개의 직사각형이 놓여 있는데 하나가 다른 하나를 포함할 수도 있으며, 변이나 꼭짓점이 겹칠 수도 있다.
이 직사각형들이 차지하는 면적을 구한다.

## 🔍 풀이 방법
좌표 내에 들어있는 부분을 1로 채워서 더한다.

## ⏳ 회고
