### PR TITLE
[20240306] BAJ/골드1/구간 합 구하기/구범모

### DIFF
--- a/BeommoKoo-dev/202403/06 2042 구간 합 구하기.md
+++ b/BeommoKoo-dev/202403/06 2042 구간 합 구하기.md
@@ -1,0 +1,105 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    class SegmentTree {
+        long[] tree;
+        int size;
+
+        public SegmentTree(int size) {
+            int h = (int)Math.ceil(Math.log(size) / Math.log(2));
+            this.size = (int)Math.pow(2, h + 1);
+            tree = new long[this.size];
+        }
+
+        public long init(long[] arr, int node, int start, int end) {
+            if (start == end) {
+                return tree[node] = arr[start];
+            }
+
+            int mid = (start + end) / 2;
+
+            return tree[node] = init(arr, node * 2, start, mid)
+                + init(arr, node * 2 + 1, mid + 1, end);
+        }
+
+        public void update(int node, int start, int end, int idx, long diff) {
+            if (idx < start || idx > end) {
+                return;
+            }
+
+            tree[node] += diff;
+
+            if (start != end) {
+                int mid = (start + end) / 2;
+                update(node * 2, start, mid, idx, diff);
+                update(node * 2 + 1, mid + 1, end, idx, diff);
+            }
+        }
+
+        public long sum(int node, int start, int end, int left, int right) {
+            if (left > end || right < start) {
+                return 0;
+            }
+
+            if (left <= start && end <= right) {
+                return tree[node];
+            }
+
+            int mid = (start + end) / 2;
+
+            return sum(node * 2, start, mid, left, right) +
+                sum(node * 2 + 1, mid + 1, end, left, right);
+        }
+    }
+
+    int n, m, k;
+    long[] arr;
+
+    private void solution() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+        arr = new long[n + 1];
+        for (int i = 1; i <= n; i++) {
+            arr[i] = Long.parseLong(br.readLine());
+        }
+
+        SegmentTree stree = new SegmentTree(n);
+
+        stree.init(arr, 1, 1, n);
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < m + k; i++) {
+            st = new StringTokenizer(br.readLine());
+            int command = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            long c = Long.parseLong(st.nextToken());
+            if (command == 1) {
+                stree.update(1, 1, n, b, c - arr[b]);
+                arr[b] = c;
+            }
+            else {
+                sb.append(Long.toString(stree.sum(1, 1, n, b, (int)c)) + '\n');
+            }
+        }
+
+        System.out.print(sb);
+
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2042

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
첫째 줄에 수의 개수 N(1 ≤ N ≤ 1,000,000)과 M(1 ≤ M ≤ 10,000), K(1 ≤ K ≤ 10,000) 가 주어진다. M은 수의 변경이 일어나는 횟수이고, K는 구간의 합을 구하는 횟수이다. 그리고 둘째 줄부터 N+1번째 줄까지 N개의 수가 주어진다. 그리고 N+2번째 줄부터 N+M+K+1번째 줄까지 세 개의 정수 a, b, c가 주어지는데, a가 1인 경우 b(1 ≤ b ≤ N)번째 수를 c로 바꾸고 a가 2인 경우에는 b(1 ≤ b ≤ N)번째 수부터 c(b ≤ c ≤ N)번째 수까지의 합을 구하여 출력하면 된다.

입력으로 주어지는 모든 수는 -2^63보다 크거나 같고, 2^63-1보다 작거나 같은 정수이다.

## 🔍 풀이 방법
기존의 dp를 이용한 구간합을 사용하면, 수를 변경하는데 O(M)이 걸리고 구간 합을 갱신하는데 O(N)이 걸리기 때문에, 전체 시간복잡도는 O(N*M)이 걸리게 되어 시간초과가 난다.
따라서 세그먼트 트리를 구현하여 구간합의 갱신을 O(logN)으로 최적화 하였다.

## ⏳ 회고
세그먼트 트리 학습용으로 문제를 풀어보았다.
