### PR TITLE
[20240306] BAJ / 실버5 / 막대기 / 신예진

### DIFF
--- a/born-A/202403/06 BAJ 막대기.md
+++ b/born-A/202403/06 BAJ 막대기.md
@@ -1,0 +1,28 @@
+```java
+import java.io.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int x = Integer.parseInt(br.readLine());
+        int[] arr = {64, 32, 16, 8, 4, 2, 1};
+        int sum = 0;
+        int count = 0;
+        
+        for(int i = 0; i < 7; i++) {
+            if(arr[i] <= x) {
+                sum += arr[i];
+                count++;
+                if(sum > x) {
+                    sum -= arr[i];
+                    count--;
+                }
+            }
+            
+            if(sum == x) break; 
+        }
+  
+        System.out.println(count);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1094

## 🧭 풀이 시간
45분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
처음에는 64cm 막대 하나만 가지고 있다. 이때, 합이 X보다 크다면, 아래와 같은 과정을 반복한다.
1. 가지고 있는 막대 중 길이가 가장 짧은 것을 절반으로 자른다.
만약, 위에서 자른 막대의 절반 중 하나를 버리고 남아있는 막대의 길이의 합이 X보다 크거나 같다면, 위에서 자른 막대의 절반 중 하나를 버린다.
2. 이제, 남아있는 모든 막대를 풀로 붙여서 Xcm를 만든다.

몇개의 막대를 붙여서 원하는 길이의 막대를 만들 수 있는지 구한다.

## 🔍 풀이 방법
64길이의 막대기로 만들수 있는 막대들은 {64, 32, 16, 8, 4, 2, 1}이다.
원하는 막대기 길이가 될때까지 더하고 빼준다.

## ⏳ 회고
문제 해석을 잘못해서 시간초과가 났다. 
어떻게 하면 답을 도출할지에 더 초점을 맞춰서 문제를 해석해야겠다.