### PR TITLE
[20240306] PRG / lv3 / 베스트앨범 / 박이슬

### DIFF
--- a/Yiseull/202403/06 PRG 베스트앨범.md
+++ b/Yiseull/202403/06 PRG 베스트앨범.md
@@ -1,0 +1,16 @@
+```python
+from collections import defaultdict
+
+
+def solution(genres: list, plays: list) -> list:
+    genre_total_plays, genre_plays = defaultdict(int), defaultdict(list)
+    for i in range(len(genres)):
+        genre_total_plays[genres[i]] += plays[i]
+        genre_plays[genres[i]].append((plays[i], i))
+        
+    answer = []
+    for genre_total_play in sorted(genre_total_plays.items(), key=lambda x: -x[1]):
+        answer += sorted(genre_plays[genre_total_play[0]], key=lambda x: (-x[0], x[1]))[:2]
+        
+    return [i[1] for i in answer]
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/42579#

## 🧭 풀이 시간
45분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
스트리밍 사이트에서 장르 별로 가장 많이 재생된 노래를 두 개씩 모아 베스트 앨범을 출시하려 합니다. 노래는 고유 번호로 구분하며, 노래를 수록하는 기준은 다음과 같습니다.

- 속한 노래가 많이 재생된 장르를 먼저 수록합니다.
- 장르 내에서 많이 재생된 노래를 먼저 수록합니다.
- 장르 내에서 재생 횟수가 같은 노래 중에서는 고유 번호가 낮은 노래를 먼저 수록합니다.

노래의 장르를 나타내는 문자열 배열 genres와 노래별 재생 횟수를 나타내는 정수 배열 plays가 주어질 때, 베스트 앨범에 들어갈 노래의 고유 번호를 순서대로 return 하도록 solution 함수를 완성하세요.

## 🔍 풀이 방법
1. 먼저 2개의 dict를 선언한다. 하나는 장르별 총 재생 수를 저장하는 딕셔너리 `genre_total_plays`고, 다른 하나는 장르별 노래와 재생 수를 저장하는 딕셔너리 `genre_plays`다.
2. 주어진 `genres`와 `plays`의 길이만큼 반복하면서 `genre_total_plays`에는 키를 장르로 하여 계속해서 재생 수를 더해주고, `genre_plays`는 키를 장르로 하여 (재생 수, 노래 고유 번호) 튜플로 저장한다.
3. `genre_total_plays`의 items에 대하여 values에 대해, 즉 총 노래 재생 수로 내림차순 정렬을 한 후 반복문을 돌린다. 속한 노래가 많이 재생된 장르부터 확인하며, 그 장르의 genre_plays를 노래 재생 수를 기준으로 내림차순을, 고유 번호를 기준으로 오름차순을 하여 0 ~ 1번째 인덱스의 값을 정답 배열에 추가한다.
4. 정답을 출력할 때는 정답 배열에서 인덱스 1번인 값들을 모아서 배열을 만들어 반환한다.

## ⏳ 회고
이 문제는 정렬을 잘못해서 처음에 틀렸었다. genre_total_plays의 Items를 보면 (키, 밸류) 형태로 나오는데 밸류로 정렬해야하는데 키값으로 정렬해서 생긴 문제였다. 하하 이런 초보적인 실수를 하다니🤦🏻‍♀️ 정신 차리자😊