### PR TITLE
[20240307] PRG / lv3 / 불량 사용자 / 박이슬

### DIFF
--- a/Yiseull/202403/07 PRG 불량 사용자.md
+++ b/Yiseull/202403/07 PRG 불량 사용자.md
@@ -1,0 +1,30 @@
+```python
+def solution(user_id: list, banned_id: list) -> int:
+    global answer
+    answer = set()
+    n, m = len(user_id), len(banned_id)
+    visited = [0] * n
+    
+    def dfs(idx: int) -> None:
+        if idx == m:
+            global answer
+            answer.add(''.join(map(str, visited)))
+            return
+        
+        for i, user in enumerate(user_id):
+            if visited[i] or len(user) != len(banned_id[idx]):
+                continue
+            possible = True
+            for j, alpha in enumerate(user):
+                if banned_id[idx][j] != '*' and banned_id[idx][j] != alpha:
+                    possible = False
+                    break
+            if possible:
+                visited[i] = 1
+                dfs(idx + 1)
+                visited[i] = 0
+    
+    dfs(0)
+    
+    return len(answer)
+```

--- a/Yiseull/202403/07 PRG 불량 사용자.md
+++ b/Yiseull/202403/07 PRG 불량 사용자.md
@@ -1,28 +1,23 @@
 ```python
 def solution(user_id: list, banned_id: list) -> int:
-    global answer
     answer = set()
     n, m = len(user_id), len(banned_id)
     visited = [0] * n
     
     def dfs(idx: int) -> None:
         if idx == m:
-            global answer
             answer.add(''.join(map(str, visited)))
             return
         
         for i, user in enumerate(user_id):
-            if visited[i] or len(user) != len(banned_id[idx]):
-                continue
-            possible = True
-            for j, alpha in enumerate(user):
-                if banned_id[idx][j] != '*' and banned_id[idx][j] != alpha:
-                    possible = False
-                    break
-            if possible:
-                visited[i] = 1
-                dfs(idx + 1)
-                visited[i] = 0
+            if not visited[i] and len(banned_id[idx]) == len(user):
+                for j, alpha in enumerate(user):
+                    if banned_id[idx][j] != '*' and banned_id[idx][j] != alpha:
+                        break
+                else:
+                    visited[i] = 1
+                    dfs(idx + 1)
+                    visited[i] = 0
     
     dfs(0)
     


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/64064

## 🧭 풀이 시간
45분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
개발팀 내에서 이벤트 개발을 담당하고 있는 "무지"는 최근 진행된 카카오이모티콘 이벤트에 비정상적인 방법으로 당첨을 시도한 응모자들을 발견하였습니다. 이런 응모자들을 따로 모아 불량 사용자라는 이름으로 목록을 만들어서 당첨 처리 시 제외하도록 이벤트 당첨자 담당자인 "프로도" 에게 전달하려고 합니다. 이 때 개인정보 보호을 위해 사용자 아이디 중 일부 문자를 '*' 문자로 가려서 전달했습니다. 

이벤트 응모자 아이디 목록이 담긴 배열 user_id와 불량 사용자 아이디 목록이 담긴 배열 banned_id가 매개변수로 주어질 때, 당첨에서 제외되어야 할 제재 아이디 목록은 몇가지 경우의 수가 가능한 지 return 하도록 solution 함수를 완성해주세요.

## 🔍 풀이 방법
👉 이 문제의 입력값들의 크기는 매우 작다. 따라서 브루트포스 알고리즘을 사용하여 전체 경우의 수를 세어준다. 이때 중복된 경우를 위해 정답 배열을 set으로 선언한다.

## ⏳ 회고
이 문제는 중복 경우의 수를 처리하는 게 가장 어려웠다. 나는 중복을 처리하기 위해 answer 배열을 set으로 선언하고, 응모자 아이디에 대한 visited 배열을 하나의 string값으로 변경하여 answer에 추가했다. 이렇게 되면 중복값은 set 특성에 의해 1번만 저장될 것이고, answer의 길이는 제재 아이디 목록의 경우의 수가 될 것이다. 