### PR TITLE
[20240308] PRG / lv3 / [복습]징검다리 / 강병곤

### DIFF
--- a/Curry4182/202403/08 징검다리.md
+++ b/Curry4182/202403/08 징검다리.md
@@ -1,0 +1,51 @@
+```java
+import java.util.*;
+
+class Solution {
+    
+    public boolean check(int[] stones, int k, int num) {
+        
+        
+        int cnt = 0;
+        for(int i=0; i<stones.length; i++) {
+            
+            int stone = stones[i];
+            
+            if(stone <= num) {
+                cnt += 1;
+            } else {
+                cnt = 0;
+            }
+            
+            if(cnt == k) {
+                return false;
+            }
+        }
+        
+        return true;
+    }
+    
+    public Integer solution(int[] stones, int k) {
+        Long min = 0L;
+        Long max = Long.valueOf(Integer.MAX_VALUE);
+        
+        Long mid  = (min + max) / 2L;
+        Long answer = Long.valueOf(Integer.MAX_VALUE);
+        while(true) {
+            if(!check(stones, k, mid.intValue())) {
+                answer = Math.min(answer, mid.intValue());
+                max = mid;
+                mid = (min + mid) / 2L;
+            } else {
+                min = mid;
+                mid = (mid + max) / 2L;
+            }
+            
+            if(max - min <= 1) {
+                return answer.intValue();
+            }
+        }
+        
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/64062

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
한 번 돌을 건널 때 마다 배열의 모든 값이 1씩 떨어진다.
그리고 원소의 값이 0일 때 그 원소는 건널 수 없다.
최대 k까지 건너뛸 수 있을 때 최대 몇번 건너뛸 수 있는지 출력한다.

## 🔍 풀이 방법
이분탐색
이 방법은 자바도 가능하다.
문제에서 요구하는 값을 x 라고 하자
x를 만족하는지 확인하는데 배열의 길이 n 만큼 시간복잡도가 든다.
x가 통과되면 늘리고 통과되지 않으면 좀 더 줄이는 방식으로 구할 때 이분탐색으로 한다면 log n의 시간 복잡도가 든다.
그러면 전체 n log n으로 통과된다.
이분탐색이 되는 이유는 java는 idx 와 value를 저장하기 위해 long으로 변경하는데 이때 발생하는 오버헤드 때문에 안되는것으로 보인다.

## ⏳ 회고
