### PR TITLE
[20240311] PRG / lv3 / 여행경로 / 박이슬

### DIFF
--- a/Yiseull/202403/11 PRG 여행경로.md
+++ b/Yiseull/202403/11 PRG 여행경로.md
@@ -1,0 +1,34 @@
+```python
+from collections import defaultdict
+
+
+def dfs(n: int, tickets_dict: dict, start: int, cnt: int) -> list:
+        if cnt == n:
+            return [start]
+        
+        for i, city in enumerate(tickets_dict[start]):
+            if city == '':
+                continue
+                
+            tickets_dict[start][i] = ''
+            result = dfs(n, tickets_dict, city, cnt + 1)
+            tickets_dict[start][i] = city
+            
+            if result:
+                return [start] + result
+        
+        return []
+
+
+def solution(tickets: list) -> list:
+    n = len(tickets)
+    tickets_dict = defaultdict(list)
+    
+    for start, end in tickets:
+        tickets_dict[start].append(end)
+        
+    for key in tickets_dict.keys():
+        tickets_dict[key].sort()
+    
+    return dfs(n, tickets_dict, 'ICN', 0)
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/43164#

## 🧭 풀이 시간
30분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
### 문제 설명
주어진 항공권을 모두 이용하여 여행경로를 짜려고 합니다. 항상 "ICN" 공항에서 출발합니다.
항공권 정보가 담긴 2차원 배열 tickets가 매개변수로 주어질 때, 방문하는 공항 경로를 배열에 담아 return 하도록 solution 함수를 작성해주세요.

### 제한사항

- 모든 공항은 알파벳 대문자 3글자로 이루어집니다.
- 주어진 공항 수는 3개 이상 10,000개 이하입니다.
- tickets의 각 행 [a, b]는 a 공항에서 b 공항으로 가는 항공권이 있다는 의미입니다.
- 주어진 항공권은 모두 사용해야 합니다.
- 만일 가능한 경로가 2개 이상일 경우 알파벳 순서가 앞서는 경로를 return 합니다.
- 모든 도시를 방문할 수 없는 경우는 주어지지 않습니다.

## 🔍 풀이 방법
1. 출발 공항에 대해서 도착 공항들을 리스트로 가지고 있는 딕셔너리를 만든다. 이때 출발 공항 여부를 체크하지 않기 위해 defaultdict를 사용한다.
2. 출발 공항에 대한 도착 공항들을 정렬한다. (기본은 오름차순 정렬이다)
3. 'ICN'부터 출발하여 정렬된 순서대로 공항들을 방문한다. 만약 모든 도시를 방문했다면 각 방문 도시들을 담아 리스트로 반환하고, 모든 도시를 방문하지 않았다면 되돌아가서 다음 순서의 공항을 방문한다.

## ⏳ 회고
처음에 제출했을 때 틀렸다. 알고보니 주어진 항공권을 모두 사용해야 한다는 조건을 고려하지 않은 것이다. 처음에 구현할 때는 무조건 정렬된 순서로 방문하고 끝내도록 했는데 이런 경우 모든 도시를 방문하지 않던 경우가 생긴다. 따라서 정렬된 순서대로 방문하되 만약 불가능한 경우에는 되돌아와서 다음 항공으로 방문하도록 했더니 통과됐다.

항상 조건들을 꼼꼼히 읽어보고 다 지켰는지 살펴보면서 풀자!