### PR TITLE
[20240311] BAJ/골드4/오렌지 출하/구범모

### DIFF
--- a/BeommoKoo-dev/202403/11 11985 오렌지 출하.md
+++ b/BeommoKoo-dev/202403/11 11985 오렌지 출하.md
@@ -1,0 +1,50 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    int n, m, k;
+    int[] arr;
+    long[] dp;
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+        arr = new int[n + 1];
+        dp = new long[n + 1];
+        Arrays.fill(dp, Long.MAX_VALUE);
+        for (int i = 1; i <= n; i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+    }
+
+    private void solution() throws IOException {
+        input();
+        dp[0] = 0;
+        for (int i = 1; i <= n; i++) {
+            int max = 0;
+            int min = Integer.MAX_VALUE;
+            for (int j = i; j < i + m; j++) {
+                if (j > n) {
+                    break;
+                }
+                max = Math.max(max, arr[j]);
+                min = Math.min(min, arr[j]);
+                int s = j - i + 1;
+                dp[j] = Math.min(dp[j], dp[i - 1] + k + (long)s * (max - min));
+            }
+        }
+        System.out.println(dp[n]);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/11985

## 🧭 풀이 시간
50분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
한 상자에는 최대 M개의 오렌지를 넣을 수 있다. 상자에 오렌지를 넣는 비용은 K + s × (a − b) 로 구할 수 있다. 여기서 a는 상자에 넣은 가장 큰 오렌지의 크기, b는 상자에 넣은 가장 작은 오렌지의 크기, s는 상자에 넣은 오렌지의 개수이다. K는 상자를 포장하는 비용이고, 모든 상자에 공통적으로 적용되는 값이다.

컨베이어 벨트 위에 놓여져 있는 오렌지의 정보와, 한 상자에 넣을 수 있는 오렌지 개수의 최댓값, 상자를 포장하는 비용 K가 주어졌을 때, 모든 오렌지를 포장하는 비용의 최솟값을 구하는 프로그램을 작성하시오.

## 🔍 풀이 방법
dp[i- 1] : i - 1번째 인덱스까지 오렌지를 담았을 때 드는 비용의 최솟값으로 정의한다.
이후 i번째 인덱스부터 시작하여 1개부터 m개의 오렌지를 담았을 때의 인덱스를 j라 하자.
이후 a,b를 for loop당 한번씩 구해주고, dp[j] = Math.min(dp[j], dp[i - 1] + k + s * (a - b))로 구할 수 있다.

## ⏳ 회고
계산중 long캐스팅을 하지 않아 오답처리된 case가 있었다. 값이 커지는 dp에서는 캐스팅 신경 잘 쓰자.