### PR TITLE
[20240314] PRG / lv3 / 등굣길 / 신예진

### DIFF
--- a/born-A/202403/14 BAJ 등굣길.md
+++ b/born-A/202403/14 BAJ 등굣길.md
@@ -1,0 +1,29 @@
+```java
+import java.util.*;
+
+class Solution {
+    public int solution(int m, int n, int[][] puddles) {
+        int mod = 1000000007;
+        int[][] dp = new int[m+1][n+1];
+    
+        for(int[] k : puddles) {
+            int a = k[0];
+            int b = k[1];
+            dp[a][b] = -1;
+        }
+        
+        dp[1][1] = 1;
+        
+        for(int i = 1; i < m+1; i++) {
+            for(int j = 1; j < n+1; j++) {
+                if(dp[i][j] == -1) {
+                    continue;
+                }
+                if(dp[i-1][j] > 0) dp[i][j] += dp[i-1][j] % mod;
+                if(dp[i][j-1] > 0) dp[i][j] += dp[i][j-1] % mod;
+            }
+        }
+        return dp[m][n] % mod;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/42898

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
m x n 사이즈의 map에서 웅덩이를 피해
오른쪽과 아래쪽으로만 움직여 집에서 학교까지 갈 수 있는 최단경로의 개수를 1,000,000,007로 나눈 나머지를 return 한다.

## 🔍 풀이 방법
왼쪽에서 오는 경우 수 + 위쪽에서 오는 경우 수를 더한 값을 구한다.

## ⏳ 회고
테스트케이스는 통과하였으나 효율성 테스트에서 실패하여 처음에 틀렸다.
1,000,000,007를 mod로 선언하여 할당하고 dp 테이블에 그 값을 넣어주어야 통과한다.
효율성 측면에서 유의해야겠다.