### PR TITLE
[20240315] BAJ / 골드5 /  백도어 / 박이슬

### DIFF
--- a/Yiseull/202403/15 BAJ 백도어.md
+++ b/Yiseull/202403/15 BAJ 백도어.md
@@ -1,0 +1,41 @@
+```python
+from heapq import *
+import sys
+input = sys.stdin.readline
+
+
+def dijkstra(n: int, graph: list, start: int) -> int:
+    q = []
+    heappush(q, (0, start))
+    distance = [sys.maxsize] * n
+    distance[start] = 0
+    while q:
+        dist, now = heappop(q)
+        if distance[now] < dist:
+            continue
+        for i in graph[now]:
+            cost = dist + i[1]
+            if cost < distance[i[0]]:
+                heappush(q, (cost, i[0]))
+                distance[i[0]] = cost
+    return distance[n - 1]
+
+
+def solution(n: int, graph: list) -> int:
+    result = dijkstra(n, graph, 0)
+    return result if result != sys.maxsize else -1
+
+
+if __name__ == '__main__':
+    n, m = map(int, input().split())
+    a = list(map(int, input().split()))
+    a[-1] = 0
+    graph = [[] for _ in range(n)]
+    for _ in range(m):
+        b, c, t = map(int, input().split())
+        if a[b] or a[c]:
+            continue
+        graph[b].append((c, t))
+        graph[c].append((b, t))
+    print(solution(n, graph))
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/17396

## 🧭 풀이 시간
60분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
최대한 빨리 게임을 끝내고 문제를 출제해야 하기 때문에 유섭이는 최대한 빨리 넥서스가 있는 곳으로 달려가려고 한다. 유섭이의 챔피언은 총 N개의 분기점에 위치할 수 있다. 0번째 분기점은 현재 유섭이의 챔피언이 있는 곳을, N-1 번째 분기점은 상대편 넥서스를 의미하며 나머지 1, 2, ..., N-2번째 분기점은 중간 거점들이다. 그러나 유섭이의 챔피언이 모든 분기점을 지나칠 수 있는 것은 아니다. 백도어의 핵심은 안 들키고 살금살금 가는 것이기 때문에 적 챔피언 혹은 적 와드(시야를 밝혀주는 토템), 미니언, 포탑 등 상대의 시야에 걸리는 곳은 지나칠 수 없다. N-1번째 분기점은 상대 넥서스이기 때문에 어쩔 수 없이 상대의 시야에 보이게 되며, 또 유일하게 상대 시야에 보이면서 갈 수 있는 곳이다.

입력으로 각 분기점을 지나칠 수 있는지에 대한 여부와 각 분기점에서 다른 분기점으로 가는데 걸리는 시간이 주어졌을 때, 유섭이가 현재 위치에서 넥서스까지 갈 수 있는 최소 시간을 구하여라.

## 🔍 풀이 방법
👉 기본적인 다익스트라 + 약간의 입력값 변형

이 문제는 입력값만 약간 수정하면 기본적인 다익스트라 알고리즘 그대로 풀 수 있는 문제다. 수정해야 하는 입력값은 각 분기점이 상대 시야에 보이는지를 알려주는 배열과 분기점 사이의 거리를 나타내는 값이다.

각 분기점이 상대 시야에 보이는지 알려주는 배열에서 1인 값은 갈 수 없는 분기점이기 때문에 1인 값에 대해서는 그래프에 경로를 추가하지 않는다. 이때 주의해야할 점은 마지막 분기점이다. 마지막 분기점은 상대의 시야에 걸리면서 가야하는 도착점이다. 따라서 마지막 분기점을 상대 시야에서 보이지 않는다는 값 0으로 변경해주고, 경로에 대한 그래프를 추가해주면 된다.

## ⏳ 회고
이 문제는 계속해서 68%에서 틀렸다. 아무리 봐도 로직은 다 맞는 것 같은데 어디서 틀린지 감이 안잡혔다. 그렇게 계속 고민하다가 혹시 distance의 최댓값이 문제인가..? 하고 계산해봤더니 내가 코드에 입력한 최댓값보다 더 큰 수가 나올 수 있다는 것을 알았다. 나는 distance의 최댓값으로 10억을 나타내는 1e9를 사용했는데 실제 정답에서는 10억을 훨씬 넘는 3000억까지 가능했다. 이를 해결하기 위해 1e9 대신 int의 최댓값을 나타내는 `sys.maxsize`를 사용했다.

당연하게 최댓값이 10억 이하라고 생각했던 사고를 부숴준 문제였다. 다음에도 로직은 맞지만 계속 틀린다면 값 설정을 잘못 해주진 않았나 살펴봐야겠다!