### PR TITLE
[20240320] BAJ/실버3/풍선 터뜨리기/구범모

### DIFF
--- a/BeommoKoo-dev/202403/20 2346 풍선 터뜨리기.md
+++ b/BeommoKoo-dev/202403/20 2346 풍선 터뜨리기.md
@@ -1,0 +1,65 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    int n;
+    ArrayDeque<Pair> dq = new ArrayDeque<>();
+
+    class Pair {
+        int idx, val;
+
+        public Pair(int idx, int val) {
+            this.idx = idx;
+            this.val = val;
+        }
+    }
+
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            dq.add(new Pair(i + 1, Integer.parseInt(st.nextToken())));
+        }
+    }
+
+    private void solution() throws IOException {
+        input();
+        StringBuilder sb = new StringBuilder();
+        int m = dq.peekFirst().val;
+        sb.append(Integer.toString(dq.pollFirst().idx) + '\n');
+        while (!dq.isEmpty()) {
+            if (m > 0) {
+                while (m-- > 1) {
+                    dq.add(dq.pollFirst());
+                }
+            }
+            else {
+                while (m++ < 0) {
+                    dq.addFirst(dq.pollLast());
+                }
+            }
+            Pair p = dq.pollFirst();
+            sb.append(Integer.toString(p.idx) + '\n');
+            m = p.val;
+        }
+        System.out.print(sb);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/2346

## 🧭 풀이 시간
10분

## 👀 체감 난이도
- [ ] 상
- [ ] 중
- [x] 하

## ✏️ 문제 설명
1번부터 N번까지 N개의 풍선이 원형으로 놓여 있고. i번 풍선의 오른쪽에는 i+1번 풍선이 있고, 왼쪽에는 i-1번 풍선이 있다. 단, 1번 풍선의 왼쪽에 N번 풍선이 있고, N번 풍선의 오른쪽에 1번 풍선이 있다. 각 풍선 안에는 종이가 하나 들어있고, 종이에는 -N보다 크거나 같고, N보다 작거나 같은 정수가 하나 적혀있다. 이 풍선들을 다음과 같은 규칙으로 터뜨린다.
우선, 제일 처음에는 1번 풍선을 터뜨린다. 다음에는 풍선 안에 있는 종이를 꺼내어 그 종이에 적혀있는 값만큼 이동하여 다음 풍선을 터뜨린다. 양수가 적혀 있을 경우에는 오른쪽으로, 음수가 적혀 있을 때는 왼쪽으로 이동한다. 이동할 때에는 이미 터진 풍선은 빼고 이동한다.
예를 들어 다섯 개의 풍선 안에 차례로 3, 2, 1, -3, -1이 적혀 있었다고 하자. 이 경우 3이 적혀 있는 1번 풍선, -3이 적혀 있는 4번 풍선, -1이 적혀 있는 5번 풍선, 1이 적혀 있는 3번 풍선, 2가 적혀 있는 2번 풍선의 순서대로 터지게 된다.

## 🔍 풀이 방법
덱을 이용하여 양수면 first를 pop하여 뒤로 보내주고, 음수면 last를 pop하여 앞에 보내준 이후, 앞에 있는 원소를 추출한다.

## ⏳ 회고
