### PR TITLE
[20240320] PRG / lv3 /  파괴되지 않은 건물 / 박이슬

### DIFF
--- a/Yiseull/202403/20 PRG 파괴되지 않은 건물.md
+++ b/Yiseull/202403/20 PRG 파괴되지 않은 건물.md
@@ -1,0 +1,29 @@
+```python
+def solution(board: list, skill: list) -> int:
+    answer = 0        
+    n, m = len(board), len(board[0])
+    skilled_board = [[0] * m for _ in range(n)]
+    
+    for type, r1, c1, r2, c2, degree in skill:
+        if type == 1: degree *= -1
+        
+        skilled_board[r1][c1] += degree
+        if c2 + 1 < m: skilled_board[r1][c2 + 1] -= degree
+        if r2 + 1 < n: skilled_board[r2 + 1][c1] -= degree
+        if c2 + 1 < m and r2 + 1 < n: skilled_board[r2 + 1][c2 + 1] += degree
+        
+    for i in range(n):
+        for j in range(1, m):
+            skilled_board[i][j] += skilled_board[i][j - 1]
+    
+    for j in range(m):
+        for i in range(1, n):
+            skilled_board[i][j] += skilled_board[i - 1][j]
+            
+    for i in range(n):
+        for j in range(m):
+            if skilled_board[i][j] + board[i][j] > 0:
+                answer += 1
+    
+    return answer
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/92344

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
N x M 크기의 행렬 모양의 게임 맵이 있습니다. 이 맵에는 내구도를 가진 건물이 각 칸마다 하나씩 있습니다. 적은 이 건물들을 공격하여 파괴하려고 합니다. 건물은 적의 공격을 받으면 내구도가 감소하고 내구도가 0이하가 되면 파괴됩니다. 반대로, 아군은 회복 스킬을 사용하여 건물들의 내구도를 높이려고 합니다.

건물의 내구도를 나타내는 2차원 정수 배열 board와 적의 공격 혹은 아군의 회복 스킬을 나타내는 2차원 정수 배열 skill이 매개변수로 주어집니다. 적의 공격 혹은 아군의 회복 스킬이 모두 끝난 뒤 파괴되지 않은 건물의 개수를 return하는 solution함수를 완성해 주세요.

## 🔍 풀이 방법
이 문제는 누적합 말고 다른 풀이로 시도한다면 시간초과가 나는 것 같습니다. 그리고 2차원 배열이기 때문에 누적합도 2차원으로 풀어야 합니다.

예를 들어, [1, 1, 1]에 대해서 0부터 1까지 2만큼의 내구도를 낮추려고 한다면, 최종 결과는 [-1, -1, 1]이 됩니다. 이때 누적합을 사용한다면 [0, 0, 0] 배열에 시작 인덱스에 +내구도, 마지막 인덱스 + 1 에 -내구도를 더하면, [-2, 0, 2]가 되고 시작 인덱스부터 누적합을 하면 [-2, -2, 0]이 됩니다. 그리고 원래의 배열과 합치면 [-1, -1, 0]이 되면서 원하는 결과를 얻을 수 있습니다.

이 방식을 2차원으로 확장하여, skill에 대하여 위와 같이 인덱스에 내구도를 더해놓고, 맨 마지막에 누적합을 계산하면 총 변화값이 나옵니다. 그리고 실제 건물의 내구도와 합하면 원하는 결과를 얻을 수 있습니다.

## ⏳ 회고
이 문제는 전에 풀어봐서 풀이를 기억했지만, 처음 보는 문제였다면 도저히 내 생각으로는 풀 수 없는 문제다. 뭐든지 경험해본 것은 쉽지만 경험하지 않은 것은 어려운 것 같다. 이런 식의 누적합 문제도 있다는 것을 기억해야겠다. 다시 풀어봐도 정말 재미있고 참신한 문제다!!😊