### PR TITLE
[20240326] BAJ/골드2/철로/구범모

### DIFF
--- a/BeommoKoo-dev/202403/26 13334 철로.md
+++ b/BeommoKoo-dev/202403/26 13334 철로.md
@@ -1,0 +1,85 @@
+```java
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    int n, d, ans;
+
+    class Position implements Comparable<Position> {
+        int from, to;
+
+        public Position(int from, int to) {
+            this.from = from;
+            this.to = to;
+        }
+
+        @Override
+        public int compareTo(Position o) {
+            if (this.to < o.to) {
+                return -1;
+            } else if (this.to == o.to) {
+                if (this.from < o.from) {
+                    return -1;
+                } else if (this.from == o.from) {
+                    return 0;
+                } return 1;
+            } return 1;
+        }
+    }
+
+    List<Position> list = new ArrayList<>();
+    Queue<Integer> pq = new PriorityQueue<>();
+
+    private void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        for (int i = 0; i < n; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int one = Integer.parseInt(st.nextToken());
+            int two = Integer.parseInt(st.nextToken());
+            list.add(new Position(Math.min(one, two), Math.max(one, two)));
+        }
+        d = Integer.parseInt(br.readLine());
+        Collections.sort(list);
+    }
+
+    private void solution() throws IOException {
+        input();
+        for (int i = 0; i < n; i++) {
+            Position p = list.get(i);
+            int from = p.from;
+            int to = p.to;
+            while (!pq.isEmpty()) {
+                int cur = pq.peek();
+                if (to - cur <= d) {
+                    break;
+                }
+                else {
+                    pq.poll();
+                }
+            }
+            if (to - from <= d) {
+                pq.add(from);
+            }
+            ans = Math.max(ans, pq.size());
+        }
+        System.out.println(ans);
+    }
+
+    public static void main(String[] args) throws IOException {
+        new Main().solution();
+    }
+
+}
+
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/13334

## 🧭 풀이 시간
40분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
집과 사무실을 통근하는 n명의 사람들이 있다. 각 사람의 집과 사무실은 수평선 상에 있는 서로 다른 점에 위치하고 있다. 임의의 두 사람 A, B에 대하여, A의 집 혹은 사무실의 위치가 B의 집 혹은 사무실의 위치와 같을 수 있다. 통근을 하는 사람들의 편의를 위하여 일직선 상의 어떤 두 점을 잇는 철로를 건설하여, 기차를 운행하려고 한다. 제한된 예산 때문에, 철로의 길이는 d로 정해져 있다. 집과 사무실의 위치 모두 철로 선분에 포함되는 사람들의 수가 최대가 되도록, 철로 선분을 정하고자 한다.

양의 정수 d와 n 개의 정수쌍, (hi, oi), 1 ≤ i ≤ n,이 주어져 있다. 여기서 hi와 oi는 사람 i의 집과 사무실의 위치이다. 길이 d의 모든 선분 L에 대하여, 집과 사무실의 위치가 모두 L에 포함되는 사람들의 최대 수를 구하는 프로그램을 작성하시오.

## 🔍 풀이 방법
사무실 오름차순, 사무실의 위치가 같다면 집 위치 오름차순으로 정렬한다. 또한 집의 위치를 오름차순으로 갖는 우선순위큐를 선언한다.
이후 list를 순회하며 우선순위큐가 비어있지 않다면, top을 꺼내 현재 사무실의 위치의 차이와 비교하여 d보다 이하일때까지 꺼낸다.
위의 작업을 마치고 나면 pq에 있는 원소의 갯수(현재 확인하는 사무실까지 포함)가 답의 후보가 되기 때문에 답을 최댓값으로 갱신 시킨다.

## ⏳ 회고
스위핑 개념에 대해서 배울 수 있는 좋은 문제.