### PR TITLE
[20240329] BAJ / 실버3 / 회전하는 큐 / 신에진

### DIFF
--- a/born-A/202403/29 BAJ 회전하는 큐.md
+++ b/born-A/202403/29 BAJ 회전하는 큐.md
@@ -1,0 +1,61 @@
+```java
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+	static int N, M;
+	static StringBuilder sb = new StringBuilder();
+	static int count = 0;
+	static LinkedList<Integer> q = new LinkedList<>();
+	
+	public static void main(String[] args) throws IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		
+		st = new StringTokenizer(br.readLine());
+		
+		int[] temp = new int[M];
+		for(int i = 0 ; i < M ; i++)
+			temp[i] = Integer.parseInt(st.nextToken());
+
+		for(int i = 1 ; i <= N ; i++)
+			q.add(i);
+		
+		for(int i = 0 ; i < M ; i++) {
+			
+			if(check(temp[i])) {
+				while(temp[i]!=q.get(0)) {
+				q.addLast(q.pollFirst());
+				count++;
+				}
+			}else {
+				while(temp[i]!=q.get(0)) {
+				q.addFirst(q.pollLast());
+				count++;
+				}
+			}
+			
+			q.poll();
+		}
+
+		
+		System.out.println(count);
+		}
+	public static boolean check(int a) {
+		
+		for(int i = 0 ; i <= q.size()/2 ; i++) {
+			if(a == q.get(i))
+				return true;
+		}
+		
+		return false;
+	}
+
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/1021

## 🧭 풀이 시간
35분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
이 큐에서 다음과 같은 3가지 연산을 수행할 수 있다.
1. 첫 번째 원소를 뽑아낸다. 이 연산을 수행하면, 원래 큐의 원소가 a1, ..., ak이었던 것이 a2, ..., ak와 같이 된다.
2. 왼쪽으로 한 칸 이동시킨다. 이 연산을 수행하면, a1, ..., ak가 a2, ..., ak, a1이 된다.
3. 오른쪽으로 한 칸 이동시킨다. 이 연산을 수행하면, a1, ..., ak가 ak, a1, ..., ak-1이 된다.

큐에 처음에 포함되어 있던 수 N이 주어진다. 그리고 지민이가 뽑아내려고 하는 원소의 위치가 주어진다.
이때, 그 원소를 주어진 순서대로 뽑아내는데 드는 2번, 3번 연산의 최솟값을 출력하는 프로그램을 작성하시오.

## 🔍 풀이 방법
q의 크기의 반보다 왼쪽에 있으면 왼쪽 연산, 오른쪽에 있으면 오른쪽 연산을 사용한다.

## ⏳ 회고
