### PR TITLE
[20240403] PRG / lv3 / 순위 / 박이슬

### DIFF
--- a/Yiseull/202404/02 PRG 시소 짝궁.md
+++ b/Yiseull/202404/02 PRG 시소 짝궁.md
@@ -1,0 +1,25 @@
+```PYTHON
+import java.util.HashMap;
+
+
+class Solution {
+    public long solution(int[] weights) {
+        long answer = 0;
+        HashMap<Long, Long> counter = new HashMap<>();
+        
+        for (long weight : weights) {
+            counter.put(weight, counter.getOrDefault(weight, 0L) + 1);
+        }
+        
+        for (long i : counter.keySet()) {
+            long count = counter.get(i);
+            answer += (count * (count - 1) / 2);
+            answer += count * counter.getOrDefault(((i * 3 / 2), 0L);
+            answer += count * counter.getOrDefault(i * 2, 0L);
+            answer += count * counter.getOrDefault((i * 4 / 3), 0L);
+        }
+        
+        return answer;
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/49191?language=java

## 🧭 풀이 시간
60분 이상

## 👀 체감 난이도
- [x] 상
- [ ] 중
- [ ] 하

## ✏️ 문제 설명
n명의 권투선수가 권투 대회에 참여했고 각각 1번부터 n번까지 번호를 받았습니다. 권투 경기는 1대1 방식으로 진행이 되고, 만약 A 선수가 B 선수보다 실력이 좋다면 A 선수는 B 선수를 항상 이깁니다. 심판은 주어진 경기 결과를 가지고 선수들의 순위를 매기려 합니다. 하지만 몇몇 경기 결과를 분실하여 정확하게 순위를 매길 수 없습니다.

선수의 수 n, 경기 결과를 담은 2차원 배열 results가 매개변수로 주어질 때 정확하게 순위를 매길 수 있는 선수의 수를 return 하도록 solution 함수를 작성해주세요.

## 🔍 풀이 방법

## ⏳ 회고
