### PR TITLE
[20240404] PRG / lv3 / 길 찾기 게임 / 박이슬

### DIFF
--- a/Yiseull/202404/04 PRG 길 찾기 게임.md
+++ b/Yiseull/202404/04 PRG 길 찾기 게임.md
@@ -1,0 +1,98 @@
+## 퍼아썬 풀이
+```python
+import sys
+sys.setrecursionlimit(10000)
+
+
+def solution(nodeinfo: list) -> list:
+    answer = [[], []]
+    
+    nodeinfo = sorted([nodeinfo[i] + [i + 1] for i in range(len(nodeinfo))])
+    
+    def order(graph: list) -> None:
+        if graph == []:
+            return
+        
+        root = 0
+        for i in range(1, len(graph)):
+            if graph[root][1] < graph[i][1]:
+                root = i
+            
+        answer[0].append(graph[root][2])
+        order(graph[:root])
+        order(graph[root + 1:])
+        answer[1].append(graph[root][2])
+        
+    order(nodeinfo)
+    
+    return answer
+```
+
+## 자바 풀이
+```java
+import java.util.*;
+
+class Solution {
+    class Node implements Comparable<Node> {
+        int x, y, index;
+
+        public Node(int x, int y, int index) {
+            this.x = x;
+            this.y = y;
+            this.index = index;
+        }
+
+        @Override
+        public int compareTo(Node other) {
+            if (this.y == other.y) {
+                return this.x - other.x;
+            }
+            return other.y - this.y;
+        }
+    }
+
+    List<Integer> preOrderList = new ArrayList<>();
+    List<Integer> postOrderList = new ArrayList<>();
+
+    public int[][] solution(int[][] nodeinfo) {
+        List<Node> nodes = new ArrayList<>();
+        for (int i = 0; i < nodeinfo.length; i++) {
+            nodes.add(new Node(nodeinfo[i][0], nodeinfo[i][1], i + 1));
+        }
+
+        Collections.sort(nodes);
+
+        order(nodes);
+
+        int[][] answer = new int[2][];
+        answer[0] = preOrderList.stream().mapToInt(i -> i).toArray();
+        answer[1] = postOrderList.stream().mapToInt(i -> i).toArray();
+
+        return answer;
+    }
+
+    private void order(List<Node> graph) {
+        if (graph.isEmpty()) {
+            return;
+        }
+
+        Node root = graph.get(0);
+        preOrderList.add(root.index);
+
+        List<Node> leftSubtree = new ArrayList<>();
+        List<Node> rightSubtree = new ArrayList<>();
+
+        for (Node node : graph) {
+            if (node.x < root.x) {
+                leftSubtree.add(node);
+            } else if (node.x > root.x) {
+                rightSubtree.add(node);
+            }
+        }
+
+        order(leftSubtree);
+        order(rightSubtree);
+        postOrderList.add(root.index);
+    }
+}
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/42892?language=java

## 🧭 풀이 시간
25분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
곤경에 빠진 카카오 프렌즈를 위해 이진트리를 구성하는 노드들의 좌표가 담긴 배열 nodeinfo가 매개변수로 주어질 때,
노드들로 구성된 이진트리를 전위 순회, 후위 순회한 결과를 2차원 배열에 순서대로 담아 return 하도록 solution 함수를 완성하자.

#### 제한 사항
- nodeinfo는 이진트리를 구성하는 각 노드의 좌표가 1번 노드부터 순서대로 들어있는 2차원 배열이다.
- nodeinfo의 길이는 1 이상 10,000 이하이다.
- nodeinfo[i] 는 i + 1번 노드의 좌표이며, [x축 좌표, y축 좌표] 순으로 들어있다.
- 모든 노드의 좌표 값은 0 이상 100,000 이하인 정수이다.
- 트리의 깊이가 1,000 이하인 경우만 입력으로 주어진다.
- 모든 노드의 좌표는 문제에 주어진 규칙을 따르며, 잘못된 노드 위치가 주어지는 경우는 없다.

## 🔍 풀이 방법
1. 노드의 x좌표에 따라 정렬하면 y좌표를 무시한 이진트리의 순서가 나온다. 이때 y좌표가 가장 작은 노드가 루트 노드가 되고 루트 노드를 기준으로 왼쪽 이진트리, 루트 노드, 오른쪽 이진트리 3가지 구역으로 나눌 수 있다.
2. 전위 순회와 후위 순회의 차이는 루트 노드의 순회 순서에만 차이가 있다. 전위 순회는 루트 노드를 가장 먼저 방문하고, 후위 순회는 루트 노드를 가장 마지막에 방문한다. 결국 왼쪽 이진트리를 순회하고 그 다음 오른쪽 이진트리를 순회하는 것은 동일하기 때문에 아래와 같이 전위 순회와 후외 순회를 같이 처리할 수 있다.
```python
def order(nodeinfo: list) -> list:
            # 루트 노드를 찾는 로직 (y좌표가 가장 작은 노드 찾기)

            answer[0].append(nodeinfo[root][2])
            order(nodeinfo[:root])
            order(nodeinfo[root+1:])
            answer[1].append(nodeinfo[root][2])
```


## ⏳ 회고
