### PR TITLE
[20240409] BAJ / 실버1 / 스티커 / 신예진

### DIFF
--- a/born-A/202404/09 BAJ 스티커.md
+++ b/born-A/202404/09 BAJ 스티커.md
@@ -1,0 +1,35 @@
+```java
+import java.io.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int tc = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < tc; i++) {
+            int n = Integer.parseInt(br.readLine());
+
+            int[][] stickers = new int[2][n+1];
+            int[][] dp = new int[2][n+1];
+            for(int j=0; j<2; j++){
+                String[] inputs = br.readLine().split(" ");
+                for (int k = 1; k <= n; k++) {
+                    stickers[j][k] = Integer.parseInt(inputs[k-1]);
+                }
+            }
+
+            dp[0][1] = stickers[0][1];
+            dp[1][1] = stickers[1][1];
+
+            for (int j = 2; j <= n; j++) {
+                dp[0][j] = Math.max(dp[1][j - 1], dp[1][j - 2]) + stickers[0][j];
+                dp[1][j] = Math.max(dp[0][j - 1], dp[0][j - 2]) + stickers[1][j];
+            }
+
+            System.out.println(Math.max(dp[0][n], dp[1][n]));
+        }
+    }
+}
+
+```


### PR DESCRIPTION
## 🧷 문제 링크
https://www.acmicpc.net/problem/9465

## 🧭 풀이 시간
35분

## 👀 체감 난이도
- [ ] 상
- [x] 중
- [ ] 하

## ✏️ 문제 설명
각 테스트 케이스 마다, 2n개의 스티커 중에서 두 변을 공유하지 않는 스티커 점수의 최댓값을 출력한다.

## 🔍 풀이 방법
왼쪽 대각선 아래, 왼쪽 대각선 아래의 왼쪽만 확인해서 더 큰 값을 현재 위치에 넣어주면 된다.

## ⏳ 회고
